### PR TITLE
docs(liz-plans): M4 GitHub issue bodies + consolidated review

### DIFF
--- a/liz-plans/M4-github-issues-bodies.md
+++ b/liz-plans/M4-github-issues-bodies.md
@@ -1,0 +1,19 @@
+# M4 — GitHub issue bodies (3 issues)
+
+Repo: `lapal0ma/LCM-PG`
+
+**Created (2026-03-23):**
+
+- P0: https://github.com/lapal0ma/LCM-PG/issues/4
+- P1: https://github.com/lapal0ma/LCM-PG/issues/5
+- P2: https://github.com/lapal0ma/LCM-PG/issues/6
+
+To recreate locally after `gh auth login`, from repo root:
+
+```bash
+gh issue create --title "M4 follow-up (P0): SK DB URL resolution + pgcrypto on managed Postgres" --body-file liz-plans/gh-issue-m4-p0.md --label m4
+gh issue create --title "M4 follow-up (P1): knowledge_roles RLS, mirror search errors, ILIKE wildcards" --body-file liz-plans/gh-issue-m4-p1.md --label m4
+gh issue create --title "M4 follow-up (P2): SK/mirror defaults, assemble timeout, mirror-search admin docs" --body-file liz-plans/gh-issue-m4-p2.md --label m4
+```
+
+If label `m4` does not exist, omit `--label m4` or create the label in the repo UI first.

--- a/liz-plans/M4-post-merge-review-issues.md
+++ b/liz-plans/M4-post-merge-review-issues.md
@@ -1,0 +1,71 @@
+# M4 Post-Merge Review — Three Priority Issues
+
+Source: code review of `feat(m4): add PG read path tools and shared knowledge integration` (e.g. commit `ef32c58` on `main`).
+
+Items are **grouped by priority** into **three** GitHub-scale issues (P0 / P1 / P2).
+
+---
+
+## P0 — Correctness / Ops (single issue)
+
+**Scope:** URL resolution + managed Postgres DDL.
+
+1. **Shared-knowledge database URL can be unresolved** — `resolveSharedKnowledgeDatabaseUrl()` only resolves when `mirrorAgentDatabaseUrls.main`, `databaseUrl`, or exactly one URL exists. Multi-URL-only setups fail or no-op without a clear startup error.  
+   **Actions:** Document config in README / `docs/configuration.md`; optional startup validation when `sharedKnowledgeEnabled && !resolveSharedKnowledgeDatabaseUrl(...)`.
+
+2. **`CREATE EXTENSION IF NOT EXISTS pgcrypto` may fail on managed Postgres** — schema init can fail on first connect where extensions are restricted.  
+   **Actions:** Document required privileges / allowlist; optional path without `pgcrypto` where `gen_random_uuid()` suffices.
+
+---
+
+## P1 — Security / Observability (single issue)
+
+**Scope:** RLS, mirror search errors, search UX.
+
+3. **`knowledge_roles` has no RLS** — any session user with `SELECT` can read the table; assumes a dedicated app DB user.  
+   **Actions:** Document threat model; optional RLS / stricter role for multi-tenant DBA concerns.
+
+4. **`searchMirror` swallows per-database errors** — `Promise.all(..., .catch(() => []))` hides failures per URL.  
+   **Actions:** Return partial results + `errors[]` or `warn` per URL; integration test for invalid URL visibility.
+
+5. **ILIKE wildcard semantics in user `query`** — `%` / `_` in user input act as SQL wildcards.  
+   **Actions:** Document, escape with `ESCAPE`, or strip for operator tools.
+
+---
+
+## P2 — Product / Defaults / Docs (single issue)
+
+**Scope:** Defaults, timeouts, admin semantics documentation.
+
+6. **Shared knowledge defaults “on” when mirror is on** — unset `LCM_SHARED_KNOWLEDGE_ENABLED` ties SK to mirror; mirror-only deploys must explicitly disable.  
+   **Actions:** README / changelog; optional default-off (breaking — semver).
+
+7. **Assemble shared-knowledge default timeout (~500ms)** — often too low for remote PG; injection skipped with warn-only.  
+   **Actions:** Document tuning / higher default; optional metric for timeout skips.
+
+8. **`lcm_mirror_search` admin when SK disabled** — admin uses `bootstrapAdminAgentIds` only, not PG `knowledge_roles`.  
+   **Actions:** Document in tool description + README.
+
+---
+
+## Already in good shape (no issue required)
+
+- Shared `Pool` via `pg-common` + `closeAllMirrorPools` / `closeAllPgPools`.
+- Transaction-scoped `set_config` for `app.agent_id` / `app.admin_role`.
+- `systemPromptAddition` append (assembler + shared knowledge).
+- `resolveAssembleAgentId` / `resolveCallerIdentity` alignment.
+- Role-group validation for `visibleTo` / `editableBy`.
+
+---
+
+## 中文摘要
+
+| 优先级 | 合并后主题 |
+|--------|------------|
+| **P0** | 共享知识库 URL 解析盲区 + 托管 PG 上 `pgcrypto` 扩展风险 |
+| **P1** | `knowledge_roles` 无 RLS、多库镜像搜索错误被吞、ILIKE 通配符 |
+| **P2** | SK 随镜像默认开启、assemble 超时偏紧、关 SK 时镜像搜索管理员规则文档 |
+
+---
+
+*Last updated: consolidated into three priority issues for GitHub.*

--- a/liz-plans/gh-issue-m4-p0.md
+++ b/liz-plans/gh-issue-m4-p0.md
@@ -1,0 +1,31 @@
+## Context
+
+Post-merge review of **M4** (PG read path tools + shared knowledge). This issue bundles all **P0** correctness / ops follow-ups.
+
+## 1. Shared-knowledge database URL can be unresolved
+
+`resolveSharedKnowledgeDatabaseUrl()` returns a URL only when:
+
+- `mirrorAgentDatabaseUrls.main` is set, **or**
+- `databaseUrl` is set, **or**
+- exactly **one** URL exists across the map + default.
+
+If operators use **only** per-agent URLs (e.g. `worker`, `research`) with **no** `main` key and **no** top-level `databaseUrl`, shared knowledge tools and assemble injection get `undefined` and fail or no-op **without a single clear startup error**.
+
+**Checklist**
+
+- [ ] Document required config shapes in README / `docs/configuration.md`
+- [ ] Optional: plugins startup **validation** — log error or fail fast when `sharedKnowledgeEnabled && !resolveSharedKnowledgeDatabaseUrl(...)`
+
+## 2. `CREATE EXTENSION IF NOT EXISTS pgcrypto` may fail on managed Postgres
+
+Schema init in `pg-reader` runs `CREATE EXTENSION IF NOT EXISTS pgcrypto`. Many hosted providers restrict extension creation; DDL can fail on first connect.
+
+**Checklist**
+
+- [ ] Document: required PG privileges / extension allowlist
+- [ ] Optional: detect PG version and skip extension when built-in `gen_random_uuid()` is sufficient, or use a migration path without `pgcrypto` where possible
+
+## Labels suggestion
+
+`m4`, `postgres`, `docs`, `config`

--- a/liz-plans/gh-issue-m4-p1.md
+++ b/liz-plans/gh-issue-m4-p1.md
@@ -1,0 +1,33 @@
+## Context
+
+Post-merge review of **M4** (PG read path tools + shared knowledge). This issue bundles all **P1** security / observability follow-ups.
+
+## 1. `knowledge_roles` has no RLS
+
+The table is readable by any DB session user with `SELECT`. Security assumes a **single application role** with no ad-hoc SQL access.
+
+**Checklist**
+
+- [ ] Document threat model: dedicated DB user; no broad human/analytics `SELECT` on app schema
+- [ ] Optional: add RLS or stricter role if multi-tenant DBA access is a concern
+
+## 2. `searchMirror` swallows per-database errors
+
+`Promise.all(..., .catch(() => []))` hides connection/query failures for individual URLs; operators see empty results instead of an error.
+
+**Checklist**
+
+- [ ] Return partial results **plus** `errors[]` in tool JSON, or `warn` with URL + message per failure
+- [ ] Integration test: failure visible when one configured URL is invalid
+
+## 3. ILIKE wildcard semantics in user `query`
+
+Mirror and shared-knowledge search use `ILIKE '%' || query || '%'`. User-supplied `%` and `_` act as SQL wildcards (surprising UX; parameters are still bound).
+
+**Checklist**
+
+- [ ] Document behavior, or escape `%` / `_` (with `ESCAPE`), or strip wildcards for operator-facing tools
+
+## Labels suggestion
+
+`m4`, `security`, `observability`, `docs`

--- a/liz-plans/gh-issue-m4-p2.md
+++ b/liz-plans/gh-issue-m4-p2.md
@@ -1,0 +1,33 @@
+## Context
+
+Post-merge review of **M4** (PG read path tools + shared knowledge). This issue bundles all **P2** product / defaults / documentation follow-ups.
+
+## 1. Shared knowledge defaults “on” when mirror is on
+
+When `LCM_SHARED_KNOWLEDGE_ENABLED` is unset, config effectively ties shared knowledge to mirror enablement. Deployments that want **mirror-only** (no RLS tables, no assemble injection) must explicitly disable shared knowledge.
+
+**Checklist**
+
+- [ ] Call out in README / changelog
+- [ ] Optional: default `sharedKnowledgeEnabled` to `false` unless explicitly set (breaking change — semver note)
+
+## 2. Assemble shared-knowledge default timeout is aggressive
+
+Default `LCM_ASSEMBLE_SK_TIMEOUT_MS` is **500ms**; remote PG often misses injection silently (warn-only).
+
+**Checklist**
+
+- [ ] Recommend higher default (e.g. 2–5s) or document tuning in ops guide
+- [ ] Optional: metric for “SK assemble skipped: timeout”
+
+## 3. Admin semantics for `lcm_mirror_search` when shared knowledge is disabled
+
+With shared knowledge off, admin for mirror search relies on **`bootstrapAdminAgentIds`** only; PG `knowledge_roles` admin is not used for that path.
+
+**Checklist**
+
+- [ ] Document clearly in tool description + README
+
+## Labels suggestion
+
+`m4`, `docs`, `product`, `ops`


### PR DESCRIPTION
Adds the markdown bodies used for GitHub issues #4–#6 and the consolidated three-priority review so issue context lives in-repo.

- `liz-plans/gh-issue-m4-p{0,1,2}.md`
- `liz-plans/M4-github-issues-bodies.md` (links + `gh` commands)
- `liz-plans/M4-post-merge-review-issues.md`

Made with [Cursor](https://cursor.com)