### PR TITLE
feat(demo): dashboard v1 SQL views + synthetic seed setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ LCM core settings (`LCM_FRESH_TAIL_COUNT`, `LCM_CONTEXT_THRESHOLD`, session patt
 | [LCM-PG-fw-validation.md](liz-plans/LCM-PG-fw-validation.md) | Validation and testing plan (Layers 1–9) / 验证测试计划 |
 | [M4/FW-M4-implementation-plan.md](liz-plans/M4/FW-M4-implementation-plan.md) | M4 implementation plan: PG read path + shared knowledge / M4 实施计划 |
 | [toB demo runbook](docs/tob-demo-macbook-runbook.md) | Fast MacBook demo flow with commands and checkpoints / MacBook 快速演示脚本 |
+| [toB dashboard v1 implementation](docs/tob-dashboard-v1-implementation.md) | SQL views + synthetic mock seeding + setup script / 看板 v1 实施落地 |
 | [deep-dive-rdbms-proposal.md](liz-plans/deep-dive-rdbms-proposal.md) | Original RDBMS exploration notes / 早期 RDBMS 探索笔记 |
 
 ### Architecture decisions

--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ LCM core settings (`LCM_FRESH_TAIL_COUNT`, `LCM_CONTEXT_THRESHOLD`, session patt
 | [toB demo runbook](docs/tob-demo-macbook-runbook.md) | Fast MacBook demo flow with commands and checkpoints / MacBook 快速演示脚本 |
 | [toB dashboard v1 implementation](docs/tob-dashboard-v1-implementation.md) | SQL views + synthetic mock seeding + setup script / 看板 v1 实施落地 |
 | [toB dashboard v1 Metabase pack](docs/tob-dashboard-v1-metabase-pack.md) | Query-to-card mapping for fast dashboard assembly / Metabase 卡片映射 |
+| [toB dashboard v1 demo-day checklist](docs/tob-dashboard-v1-demo-day-checklist.md) | Pre-demo QA gate and fallback playbook / 演示前检查与兜底 |
 | [deep-dive-rdbms-proposal.md](liz-plans/deep-dive-rdbms-proposal.md) | Original RDBMS exploration notes / 早期 RDBMS 探索笔记 |
 
 ### Architecture decisions

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ LCM core settings (`LCM_FRESH_TAIL_COUNT`, `LCM_CONTEXT_THRESHOLD`, session patt
 | [M4/FW-M4-implementation-plan.md](liz-plans/M4/FW-M4-implementation-plan.md) | M4 implementation plan: PG read path + shared knowledge / M4 实施计划 |
 | [toB demo runbook](docs/tob-demo-macbook-runbook.md) | Fast MacBook demo flow with commands and checkpoints / MacBook 快速演示脚本 |
 | [toB dashboard v1 implementation](docs/tob-dashboard-v1-implementation.md) | SQL views + synthetic mock seeding + setup script / 看板 v1 实施落地 |
+| [toB dashboard v1 Metabase pack](docs/tob-dashboard-v1-metabase-pack.md) | Query-to-card mapping for fast dashboard assembly / Metabase 卡片映射 |
 | [deep-dive-rdbms-proposal.md](liz-plans/deep-dive-rdbms-proposal.md) | Original RDBMS exploration notes / 早期 RDBMS 探索笔记 |
 
 ### Architecture decisions

--- a/docs/tob-dashboard-v1-demo-day-checklist.md
+++ b/docs/tob-dashboard-v1-demo-day-checklist.md
@@ -1,0 +1,128 @@
+# toB Dashboard v1 Demo-Day Checklist
+# toB 看板 v1 演示日检查清单
+
+Use this checklist right before stakeholder demos.
+用于正式演示前的最后检查。
+
+---
+
+## 1) T-30 min: Environment / 环境检查
+
+### EN
+
+1. Confirm PostgreSQL is running.
+2. Confirm target DB is reachable (`lcm_demo` by default).
+3. Confirm repo branch is the approved demo branch.
+
+### 中文
+
+1. 确认 PostgreSQL 服务已启动。
+2. 确认目标数据库可连接（默认 `lcm_demo`）。
+3. 确认当前仓库在已批准的演示分支。
+
+---
+
+## 2) T-20 min: Data + View Setup / 数据与视图准备
+
+Run:
+
+```bash
+cd /Users/lizbai/Documents/OpenClaw/VibeCoding/LCM-PG
+scripts/tob-dashboard/setup-v1.sh
+```
+
+Expected:
+
+- mock rows inserted (idempotent)
+- dashboard views created/updated
+
+---
+
+## 3) T-15 min: QA Gate / QA 闸门
+
+Run:
+
+```bash
+scripts/tob-dashboard/qa-v1.sh
+```
+
+Pass criteria (default thresholds):
+
+- `lcm_mirror` rows >= 200
+- `shared_knowledge` rows >= 40
+- role rows >= 4
+- distinct tags (30d) >= 8
+- restricted entries (30d) >= 1
+- shift spikes (72h) >= 2
+
+Custom thresholds (optional):
+
+```bash
+MIRROR_MIN_ROWS=180 TAGS_MIN_COUNT=10 scripts/tob-dashboard/qa-v1.sh
+```
+
+---
+
+## 4) T-10 min: Dashboard Spot Check / 看板抽查
+
+Open Metabase dashboard `LCM-PG toB Dashboard v1` and verify:
+
+1. Context Shift line chart renders (per-agent series visible).
+2. Top Tags card has at least 8 tags.
+3. Governance visibility chart shows restricted entries.
+4. Recent curated knowledge table is non-empty.
+
+打开 Metabase 看板 `LCM-PG toB Dashboard v1` 并确认：
+
+1. Context Shift 折线图正常展示（按 agent 分组）。
+2. Top Tags 至少显示 8 个标签。
+3. Governance 可见性图中存在 restricted 数据。
+4. 最新知识明细表非空。
+
+---
+
+## 5) T-5 min: Narrative Alignment / 话术校准
+
+Use this 3-point narrative:
+
+1. Context shift is measurable (`vw_context_shift_hourly`).
+2. Knowledge topics are structured via tags (`vw_topic_trends_daily`).
+3. Governance is auditable (`vw_governance_visibility_daily`, `vw_governance_role_matrix`).
+
+演示话术建议 3 点：
+
+1. 上下文迁移可量化（`vw_context_shift_hourly`）。
+2. 主题通过标签结构化（`vw_topic_trends_daily`）。
+3. 治理状态可审计（`vw_governance_visibility_daily`、`vw_governance_role_matrix`）。
+
+---
+
+## 6) One-Command Option / 一键执行
+
+If you want setup + QA in one command:
+
+```bash
+scripts/tob-dashboard/demo-ready-v1.sh
+```
+
+若希望一键完成“准备 + QA”：
+
+```bash
+scripts/tob-dashboard/demo-ready-v1.sh
+```
+
+---
+
+## 7) Fallback Playbook / 兜底预案
+
+### EN
+
+- If DB is unavailable: switch to pre-captured screenshots + previously exported CSV metrics.
+- If tags are too sparse: rerun setup seeder and refresh Metabase cache.
+- If chart render is slow: reduce dashboard time window from 30d to 7d for live demo.
+
+### 中文
+
+- 如果数据库不可用：切换到预先导出的截图与 CSV 指标。
+- 如果标签分布稀疏：重新执行 seed，并刷新 Metabase 缓存。
+- 如果图表加载慢：现场将时间窗口从 30 天缩短到 7 天。

--- a/docs/tob-dashboard-v1-implementation.md
+++ b/docs/tob-dashboard-v1-implementation.md
@@ -1,0 +1,117 @@
+# toB Dashboard v1 Implementation Guide
+# toB 看板 v1 实施指南
+
+This guide implements the decisions in:
+`docs/tob-dashboard-demo-flow-plan.md` §8
+
+本指南对应：
+`docs/tob-dashboard-demo-flow-plan.md` 第 8 节的 v1 决策。
+
+---
+
+## 1) Scope (v1) / 范围（v1）
+
+### EN
+
+- SQL-view-only analytics (no API layer)
+- Single workspace
+- Topic analytics from `shared_knowledge.tags` only
+- Full synthetic playback as primary data strategy
+
+### 中文
+
+- 仅使用 SQL 视图分析（不加 API 层）
+- 单 workspace
+- 主题分析仅基于 `shared_knowledge.tags`
+- 以全量模拟回放作为主数据策略
+
+---
+
+## 2) Artifacts / 产物
+
+- Seeder SQL:
+  `sql/tob-dashboard/v1_seed_mock_data.sql`
+- View SQL:
+  `sql/tob-dashboard/v1_views.sql`
+- One-command setup:
+  `scripts/tob-dashboard/setup-v1.sh`
+
+---
+
+## 3) Quick Start / 快速启动
+
+```bash
+cd /Users/lizbai/Documents/OpenClaw/VibeCoding/LCM-PG
+
+# Optional: ensure DB exists first
+createdb lcm_demo 2>/dev/null || true
+
+# Use default URL (postgresql://$(whoami)@localhost:5432/lcm_demo)
+scripts/tob-dashboard/setup-v1.sh
+
+# Or pass a URL explicitly
+scripts/tob-dashboard/setup-v1.sh "postgresql://user:pass@localhost:5432/lcm_demo"
+```
+
+---
+
+## 4) Verification SQL / 验证 SQL
+
+```bash
+psql "postgresql://$(whoami)@localhost:5432/lcm_demo" -c \
+"select count(*) as mirror_rows from lcm_mirror;"
+
+psql "postgresql://$(whoami)@localhost:5432/lcm_demo" -c \
+"select count(*) as shared_rows from shared_knowledge;"
+
+psql "postgresql://$(whoami)@localhost:5432/lcm_demo" -c \
+"select * from vw_context_shift_hourly limit 10;"
+
+psql "postgresql://$(whoami)@localhost:5432/lcm_demo" -c \
+"select * from vw_topic_trends_daily limit 10;"
+
+psql "postgresql://$(whoami)@localhost:5432/lcm_demo" -c \
+"select * from vw_governance_role_matrix;"
+```
+
+---
+
+## 5) Recommended Metabase Cards / 推荐 Metabase 卡片
+
+### EN
+
+Build dashboard cards from these views:
+
+- `vw_context_shift_hourly`: line chart by `bucket_hour`, series `agent_id`, metric `shift_score_avg`
+- `vw_context_volume_daily`: stacked bars by `day`, grouped by `agent_id`
+- `vw_topic_trends_daily`: top tags by `entries`
+- `vw_topic_momentum_7d`: table sorted by `delta_7d DESC`
+- `vw_governance_visibility_daily`: visibility ratio trend
+- `vw_governance_role_matrix`: governance matrix table
+
+### 中文
+
+建议基于以下视图建卡片：
+
+- `vw_context_shift_hourly`：按 `bucket_hour` 的折线图，序列 `agent_id`，指标 `shift_score_avg`
+- `vw_context_volume_daily`：按 `day` 的堆叠柱状图（按 `agent_id` 分组）
+- `vw_topic_trends_daily`：高频标签排行
+- `vw_topic_momentum_7d`：按 `delta_7d` 降序的动量表
+- `vw_governance_visibility_daily`：可见性占比趋势
+- `vw_governance_role_matrix`：治理权限矩阵表
+
+---
+
+## 6) Notes / 说明
+
+### EN
+
+- Seeder is idempotent on primary keys / unique constraints.
+- Re-running setup updates views and appends only non-conflicting mock rows.
+- If your environment has strict RLS enabled, run seeding with a DB user that can insert demo rows.
+
+### 中文
+
+- Seed 脚本在主键/唯一键层面可重复执行。
+- 重复运行会刷新视图，只插入不冲突的数据。
+- 若环境启用了严格 RLS，请使用有插入权限的数据库账号执行演示注入。

--- a/docs/tob-dashboard-v1-implementation.md
+++ b/docs/tob-dashboard-v1-implementation.md
@@ -35,6 +35,10 @@ This guide implements the decisions in:
   `sql/tob-dashboard/v1_views.sql`
 - One-command setup:
   `scripts/tob-dashboard/setup-v1.sh`
+- Metabase card pack guide:
+  `docs/tob-dashboard-v1-metabase-pack.md`
+- Metabase query files:
+  `sql/tob-dashboard/metabase/v1/*.sql`
 
 ---
 

--- a/docs/tob-dashboard-v1-implementation.md
+++ b/docs/tob-dashboard-v1-implementation.md
@@ -35,10 +35,16 @@ This guide implements the decisions in:
   `sql/tob-dashboard/v1_views.sql`
 - One-command setup:
   `scripts/tob-dashboard/setup-v1.sh`
+- QA gate script:
+  `scripts/tob-dashboard/qa-v1.sh`
+- One-command setup + QA:
+  `scripts/tob-dashboard/demo-ready-v1.sh`
 - Metabase card pack guide:
   `docs/tob-dashboard-v1-metabase-pack.md`
 - Metabase query files:
   `sql/tob-dashboard/metabase/v1/*.sql`
+- Demo-day checklist:
+  `docs/tob-dashboard-v1-demo-day-checklist.md`
 
 ---
 

--- a/docs/tob-dashboard-v1-metabase-pack.md
+++ b/docs/tob-dashboard-v1-metabase-pack.md
@@ -1,0 +1,141 @@
+# toB Dashboard v1 Metabase Pack
+# toB 看板 v1 Metabase 查询与卡片包
+
+This document is Step 2 of implementation:
+- Step 1: SQL views + synthetic seeding
+- Step 2: Metabase query/card pack (this file)
+
+本文是实施第 2 步：
+- 第 1 步：SQL 视图 + 模拟数据注入
+- 第 2 步：Metabase 查询与卡片包（本文）
+
+---
+
+## 1) Prerequisite / 前置条件
+
+Run Step 1 first:
+
+```bash
+scripts/tob-dashboard/setup-v1.sh
+```
+
+Then connect Metabase to the same PostgreSQL database (`lcm_demo` by default).
+
+---
+
+## 2) Dashboard Tabs / 看板分栏
+
+Create one dashboard with 3 tabs:
+
+1. `Context Shift`
+2. `Knowledge Topics`
+3. `Governance`
+
+建议使用一个 Dashboard，分 3 个标签页：
+
+1. `Context Shift`
+2. `Knowledge Topics`
+3. `Governance`
+
+---
+
+## 3) Card Catalog (Exact Mapping) / 卡片清单（精确映射）
+
+| Card # | Query File | Tab | Visualization | Config (important) |
+|---|---|---|---|---|
+| 01 | `sql/tob-dashboard/metabase/v1/01_kpi_overview.sql` | Context Shift | Table (single row) | Show as KPI-style summary block |
+| 02 | `sql/tob-dashboard/metabase/v1/02_context_shift_trend.sql` | Context Shift | Line | X=`bucket_hour`, Y=`shift_score_avg`, Breakout=`agent_id` |
+| 03 | `sql/tob-dashboard/metabase/v1/03_context_volume_daily.sql` | Context Shift | Stacked bar | X=`day`, Y=`snapshots`, Breakout=`agent_id` |
+| 04 | `sql/tob-dashboard/metabase/v1/04_context_latest_snapshots.sql` | Context Shift | Table | Sort `captured_at desc`; keep columns concise |
+| 05 | `sql/tob-dashboard/metabase/v1/05_topic_top_tags_30d.sql` | Knowledge Topics | Horizontal bar | Y=`tag`, X=`entries_30d`, sort descending |
+| 06 | `sql/tob-dashboard/metabase/v1/06_topic_daily_trend_top8.sql` | Knowledge Topics | Stacked area (or multi-line) | X=`day`, Y=`entries`, Breakout=`tag` |
+| 07 | `sql/tob-dashboard/metabase/v1/07_topic_momentum_7d.sql` | Knowledge Topics | Table | Sort `delta_7d desc` |
+| 10 | `sql/tob-dashboard/metabase/v1/10_recent_curated_knowledge.sql` | Knowledge Topics | Table | Sort `updated_at desc`; include visibility + tags |
+| 08 | `sql/tob-dashboard/metabase/v1/08_governance_visibility_daily.sql` | Governance | Stacked bar | X=`day`, Y=`shared/restricted/private` |
+| 09 | `sql/tob-dashboard/metabase/v1/09_governance_role_matrix.sql` | Governance | Table | Sort by `agent_id`, `role` |
+
+---
+
+## 4) Recommended Layout / 推荐布局
+
+### EN
+
+`Context Shift` tab:
+- Top row: Card 01 (full width KPI)
+- Mid row: Card 02 (left, 2/3) + Card 03 (right, 1/3)
+- Bottom row: Card 04 (full width table)
+
+`Knowledge Topics` tab:
+- Top row: Card 05 (left, 1/2) + Card 07 (right, 1/2)
+- Mid row: Card 06 (full width trend)
+- Bottom row: Card 10 (full width table)
+
+`Governance` tab:
+- Top row: Card 08 (left, 1/2) + Card 09 (right, 1/2)
+
+### 中文
+
+`Context Shift` 页：
+- 顶部：卡片 01（整行 KPI）
+- 中部：卡片 02（左侧 2/3）+ 卡片 03（右侧 1/3）
+- 底部：卡片 04（整行明细表）
+
+`Knowledge Topics` 页：
+- 顶部：卡片 05（左 1/2）+ 卡片 07（右 1/2）
+- 中部：卡片 06（整行趋势图）
+- 底部：卡片 10（整行明细表）
+
+`Governance` 页：
+- 顶部：卡片 08（左 1/2）+ 卡片 09（右 1/2）
+
+---
+
+## 5) Optional Dashboard Filters / 可选全局筛选
+
+### EN
+
+For v1 simplicity, queries already scope to recent windows (e.g. 30d/72h).
+You may still add UI filters:
+- Date range (for tabs with `day`/`bucket_hour`)
+- Agent (for context views)
+- Visibility (for governance and recent knowledge table)
+
+### 中文
+
+v1 以简洁为主，查询已内置时间窗口（如 30 天、72 小时）。
+如需可加 UI 全局筛选：
+- 时间范围（`day`/`bucket_hour`）
+- Agent（上下文页）
+- Visibility（治理与知识明细页）
+
+---
+
+## 6) Demo Talk Track Binding / 与演示话术绑定
+
+### EN
+
+- “Context is shifting and traceable” -> Cards 02 + 04
+- “Knowledge gets structured into reusable topics” -> Cards 05 + 06 + 07
+- “Governance is visible and auditable” -> Cards 08 + 09 + 10
+
+### 中文
+
+- “上下文变化可追踪” -> 卡片 02 + 04
+- “知识被结构化并可复用” -> 卡片 05 + 06 + 07
+- “治理状态可见且可审计” -> 卡片 08 + 09 + 10
+
+---
+
+## 7) Quick Build Checklist / 快速搭建清单
+
+1. Run `scripts/tob-dashboard/setup-v1.sh`.
+2. In Metabase, create 10 native SQL questions from the query files above.
+3. Set visualization exactly per table in §3.
+4. Assemble into the 3-tab dashboard per §4.
+5. Save dashboard as: `LCM-PG toB Dashboard v1`.
+
+1. 执行 `scripts/tob-dashboard/setup-v1.sh`。
+2. 在 Metabase 中用上述 SQL 文件创建 10 个原生查询问题。
+3. 按第 3 节设置图表类型与字段。
+4. 按第 4 节组装成 3 个分栏的 Dashboard。
+5. 保存名称：`LCM-PG toB Dashboard v1`。

--- a/scripts/tob-dashboard/demo-ready-v1.sh
+++ b/scripts/tob-dashboard/demo-ready-v1.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEFAULT_URL="postgresql://$(whoami)@localhost:5432/lcm_demo"
+PG_URL="${1:-${LCM_DEMO_PG_URL:-${TEST_PG_URL:-$DEFAULT_URL}}}"
+
+echo "[lcm-pg] Demo-ready pipeline v1"
+echo "[lcm-pg] DB: ${PG_URL}"
+
+"${ROOT_DIR}/scripts/tob-dashboard/setup-v1.sh" "${PG_URL}"
+"${ROOT_DIR}/scripts/tob-dashboard/qa-v1.sh" "${PG_URL}"
+
+echo "[lcm-pg] Environment is demo-ready."

--- a/scripts/tob-dashboard/qa-v1.sh
+++ b/scripts/tob-dashboard/qa-v1.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEFAULT_URL="postgresql://$(whoami)@localhost:5432/lcm_demo"
+PG_URL="${1:-${LCM_DEMO_PG_URL:-${TEST_PG_URL:-$DEFAULT_URL}}}"
+
+SPIKE_THRESHOLD="${SHIFT_SPIKE_THRESHOLD:-0.25}"
+MIRROR_MIN_ROWS="${MIRROR_MIN_ROWS:-200}"
+SHARED_MIN_ROWS="${SHARED_MIN_ROWS:-40}"
+ROLES_MIN_ROWS="${ROLES_MIN_ROWS:-4}"
+TAGS_MIN_COUNT="${TAGS_MIN_COUNT:-8}"
+RESTRICTED_MIN_COUNT="${RESTRICTED_MIN_COUNT:-1}"
+SPIKES_MIN_COUNT="${SPIKES_MIN_COUNT:-2}"
+
+pass_count=0
+fail_count=0
+
+pass() {
+  echo "[PASS] $1"
+  pass_count=$((pass_count + 1))
+}
+
+fail() {
+  echo "[FAIL] $1"
+  fail_count=$((fail_count + 1))
+}
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "[ERROR] Missing command: $1"
+    exit 1
+  fi
+}
+
+sql_scalar() {
+  local q="$1"
+  psql "${PG_URL}" -v ON_ERROR_STOP=1 -Atqc "${q}"
+}
+
+as_int() {
+  local v="${1:-0}"
+  v="${v%%.*}"
+  if [[ -z "${v}" || "${v}" == "null" ]]; then
+    echo "0"
+    return
+  fi
+  echo "${v}"
+}
+
+cmp_ge() {
+  awk -v a="$1" -v b="$2" 'BEGIN { exit !(a >= b) }'
+}
+
+check_ge() {
+  local name="$1"
+  local value="$2"
+  local min="$3"
+  if cmp_ge "${value}" "${min}"; then
+    pass "${name}: ${value} >= ${min}"
+  else
+    fail "${name}: ${value} < ${min}"
+  fi
+}
+
+check_view_exists() {
+  local view="$1"
+  local exists
+  exists="$(sql_scalar "SELECT count(*) FROM information_schema.views WHERE table_schema='public' AND table_name='${view}';")"
+  exists="$(as_int "${exists}")"
+  if [[ "${exists}" -ge 1 ]]; then
+    pass "view exists: ${view}"
+  else
+    fail "view missing: ${view} (run ${ROOT_DIR}/sql/tob-dashboard/v1_views.sql)"
+  fi
+}
+
+echo "[lcm-pg] QA v1 starting"
+echo "[lcm-pg] DB: ${PG_URL}"
+echo "[lcm-pg] thresholds: mirror>=${MIRROR_MIN_ROWS}, shared>=${SHARED_MIN_ROWS}, roles>=${ROLES_MIN_ROWS}, tags>=${TAGS_MIN_COUNT}, restricted>=${RESTRICTED_MIN_COUNT}, spikes>=${SPIKES_MIN_COUNT}, spike_threshold>=${SPIKE_THRESHOLD}"
+
+need_cmd psql
+
+if psql "${PG_URL}" -v ON_ERROR_STOP=1 -Atqc "SELECT 1;" >/dev/null 2>&1; then
+  pass "database connectivity"
+else
+  echo "[ERROR] cannot connect to PostgreSQL at ${PG_URL}"
+  echo "Hint: run scripts/tob-dashboard/setup-v1.sh first."
+  exit 1
+fi
+
+# Required views (Step 1 deliverables).
+for v in \
+  vw_context_shift_hourly \
+  vw_context_volume_daily \
+  vw_topic_trends_daily \
+  vw_topic_momentum_7d \
+  vw_governance_visibility_daily \
+  vw_governance_role_matrix
+do
+  check_view_exists "${v}"
+done
+
+# Core dataset size checks.
+mirror_rows="$(as_int "$(sql_scalar "SELECT count(*) FROM lcm_mirror;")")"
+shared_rows="$(as_int "$(sql_scalar "SELECT count(*) FROM shared_knowledge;")")"
+roles_rows="$(as_int "$(sql_scalar "SELECT count(*) FROM knowledge_roles;")")"
+
+check_ge "lcm_mirror row count" "${mirror_rows}" "${MIRROR_MIN_ROWS}"
+check_ge "shared_knowledge row count" "${shared_rows}" "${SHARED_MIN_ROWS}"
+check_ge "knowledge_roles row count" "${roles_rows}" "${ROLES_MIN_ROWS}"
+
+# Topic quality checks (tags-only v1 decision).
+distinct_tags_30d="$(as_int "$(sql_scalar "SELECT count(DISTINCT tag) FROM vw_topic_trends_daily WHERE day >= current_date - 30;")")"
+check_ge "distinct topic tags in last 30d" "${distinct_tags_30d}" "${TAGS_MIN_COUNT}"
+
+# Governance checks.
+restricted_entries_30d="$(as_int "$(sql_scalar "SELECT COALESCE(sum(restricted_entries),0) FROM vw_governance_visibility_daily WHERE day >= current_date - 30;")")"
+check_ge "restricted entries in last 30d" "${restricted_entries_30d}" "${RESTRICTED_MIN_COUNT}"
+
+role_matrix_rows="$(as_int "$(sql_scalar "SELECT count(*) FROM vw_governance_role_matrix;")")"
+check_ge "role matrix rows" "${role_matrix_rows}" "${ROLES_MIN_ROWS}"
+
+# Context-shift demo signal checks.
+spike_count_72h="$(as_int "$(sql_scalar "SELECT count(*) FROM vw_context_shift_hourly WHERE bucket_hour >= now() - interval '72 hours' AND shift_score_peak >= ${SPIKE_THRESHOLD};")")"
+check_ge "context shift spikes in last 72h" "${spike_count_72h}" "${SPIKES_MIN_COUNT}"
+
+echo
+echo "[lcm-pg] QA summary: pass=${pass_count}, fail=${fail_count}"
+if [[ "${fail_count}" -gt 0 ]]; then
+  echo "[lcm-pg] QA FAILED"
+  exit 1
+fi
+
+echo "[lcm-pg] QA PASSED"
+echo "[lcm-pg] Recommended next step: build/refresh Metabase dashboard cards from docs/tob-dashboard-v1-metabase-pack.md"

--- a/scripts/tob-dashboard/setup-v1.sh
+++ b/scripts/tob-dashboard/setup-v1.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEFAULT_URL="postgresql://$(whoami)@localhost:5432/lcm_demo"
+
+PG_URL="${1:-${LCM_DEMO_PG_URL:-${TEST_PG_URL:-$DEFAULT_URL}}}"
+
+echo "[lcm-pg] Using PostgreSQL URL: ${PG_URL}"
+echo "[lcm-pg] Seeding deterministic mock data..."
+psql "${PG_URL}" -v ON_ERROR_STOP=1 -f "${ROOT_DIR}/sql/tob-dashboard/v1_seed_mock_data.sql"
+
+echo "[lcm-pg] Creating dashboard views..."
+psql "${PG_URL}" -v ON_ERROR_STOP=1 -f "${ROOT_DIR}/sql/tob-dashboard/v1_views.sql"
+
+echo "[lcm-pg] Done."
+echo "[lcm-pg] Quick checks:"
+echo "  psql \"${PG_URL}\" -c \"select * from vw_context_shift_hourly limit 5;\""
+echo "  psql \"${PG_URL}\" -c \"select * from vw_topic_momentum_7d limit 10;\""

--- a/sql/tob-dashboard/metabase/v1/01_kpi_overview.sql
+++ b/sql/tob-dashboard/metabase/v1/01_kpi_overview.sql
@@ -1,0 +1,19 @@
+-- Card: KPI Overview (single-row table)
+-- Purpose: headline health metrics for demo opening.
+
+SELECT
+  now() AS snapshot_ts,
+  (SELECT count(*) FROM lcm_mirror) AS mirror_rows_total,
+  (SELECT count(*) FROM shared_knowledge) AS shared_knowledge_rows_total,
+  (SELECT count(*) FROM knowledge_roles) AS role_assignments_total,
+  (SELECT count(*) FROM lcm_mirror WHERE captured_at >= now() - interval '24 hours') AS mirror_rows_24h,
+  (
+    SELECT COALESCE(round(avg(shift_score_avg), 4), 0)
+    FROM vw_context_shift_hourly
+    WHERE bucket_hour >= now() - interval '24 hours'
+  ) AS avg_shift_score_24h,
+  (
+    SELECT COALESCE(count(*), 0)
+    FROM shared_knowledge
+    WHERE visibility = 'restricted'
+  ) AS restricted_knowledge_rows;

--- a/sql/tob-dashboard/metabase/v1/02_context_shift_trend.sql
+++ b/sql/tob-dashboard/metabase/v1/02_context_shift_trend.sql
@@ -1,0 +1,14 @@
+-- Card: Context Shift Trend by Agent
+-- Viz: line chart
+-- X: bucket_hour, Breakout: agent_id, Y: shift_score_avg
+
+SELECT
+  bucket_hour,
+  agent_id,
+  shift_score_avg,
+  shift_score_peak,
+  snapshots,
+  active_conversations
+FROM vw_context_shift_hourly
+WHERE bucket_hour >= now() - interval '72 hours'
+ORDER BY bucket_hour ASC, agent_id ASC;

--- a/sql/tob-dashboard/metabase/v1/03_context_volume_daily.sql
+++ b/sql/tob-dashboard/metabase/v1/03_context_volume_daily.sql
@@ -1,0 +1,16 @@
+-- Card: Context Volume Daily
+-- Viz: stacked bar
+-- X: day, Breakout: agent_id
+-- Y: snapshots (or avg_content_chars as toggle)
+
+SELECT
+  day,
+  agent_id,
+  snapshots,
+  active_conversations,
+  avg_content_chars,
+  p95_content_chars,
+  avg_summary_nodes
+FROM vw_context_volume_daily
+WHERE day >= current_date - 30
+ORDER BY day ASC, agent_id ASC;

--- a/sql/tob-dashboard/metabase/v1/04_context_latest_snapshots.sql
+++ b/sql/tob-dashboard/metabase/v1/04_context_latest_snapshots.sql
@@ -1,0 +1,15 @@
+-- Card: Latest Mirror Snapshots
+-- Viz: table
+-- Purpose: operator drill-down and spot checks.
+
+SELECT
+  captured_at,
+  agent_id,
+  conversation_id,
+  mode,
+  char_length(content) AS content_chars,
+  COALESCE(jsonb_array_length(summary_ids), 0) AS summary_nodes,
+  left(regexp_replace(content, '\s+', ' ', 'g'), 220) AS content_snippet
+FROM lcm_mirror
+ORDER BY captured_at DESC
+LIMIT 150;

--- a/sql/tob-dashboard/metabase/v1/05_topic_top_tags_30d.sql
+++ b/sql/tob-dashboard/metabase/v1/05_topic_top_tags_30d.sql
@@ -1,0 +1,15 @@
+-- Card: Top Topic Tags (30d)
+-- Viz: horizontal bar
+-- X: entries_30d, Y: tag
+
+SELECT
+  tag,
+  sum(entries) AS entries_30d,
+  sum(shared_entries) AS shared_entries_30d,
+  sum(restricted_entries) AS restricted_entries_30d,
+  sum(private_entries) AS private_entries_30d
+FROM vw_topic_trends_daily
+WHERE day >= current_date - 30
+GROUP BY tag
+ORDER BY entries_30d DESC, tag ASC
+LIMIT 15;

--- a/sql/tob-dashboard/metabase/v1/06_topic_daily_trend_top8.sql
+++ b/sql/tob-dashboard/metabase/v1/06_topic_daily_trend_top8.sql
@@ -1,0 +1,23 @@
+-- Card: Topic Daily Trend (Top 8 tags)
+-- Viz: stacked area or multi-line
+-- X: day, Breakout: tag, Y: entries
+
+WITH top_tags AS (
+  SELECT
+    tag,
+    sum(entries) AS total_entries
+  FROM vw_topic_trends_daily
+  WHERE day >= current_date - 30
+  GROUP BY tag
+  ORDER BY total_entries DESC, tag ASC
+  LIMIT 8
+)
+SELECT
+  t.day,
+  t.tag,
+  t.entries
+FROM vw_topic_trends_daily t
+JOIN top_tags x
+  ON x.tag = t.tag
+WHERE t.day >= current_date - 30
+ORDER BY t.day ASC, t.tag ASC;

--- a/sql/tob-dashboard/metabase/v1/07_topic_momentum_7d.sql
+++ b/sql/tob-dashboard/metabase/v1/07_topic_momentum_7d.sql
@@ -1,0 +1,13 @@
+-- Card: Topic Momentum (7d vs previous 7d)
+-- Viz: table (sortable), optionally bar by delta_7d
+
+SELECT
+  anchor_day,
+  tag,
+  recent_7d,
+  previous_7d,
+  delta_7d,
+  growth_ratio
+FROM vw_topic_momentum_7d
+ORDER BY delta_7d DESC, recent_7d DESC, tag ASC
+LIMIT 25;

--- a/sql/tob-dashboard/metabase/v1/08_governance_visibility_daily.sql
+++ b/sql/tob-dashboard/metabase/v1/08_governance_visibility_daily.sql
@@ -1,0 +1,14 @@
+-- Card: Governance Visibility Mix
+-- Viz: stacked bar or line
+-- X: day, Y: shared/restricted/private entries
+
+SELECT
+  day,
+  total_entries,
+  shared_entries,
+  restricted_entries,
+  private_entries,
+  restricted_ratio
+FROM vw_governance_visibility_daily
+WHERE day >= current_date - 30
+ORDER BY day ASC;

--- a/sql/tob-dashboard/metabase/v1/09_governance_role_matrix.sql
+++ b/sql/tob-dashboard/metabase/v1/09_governance_role_matrix.sql
@@ -1,0 +1,13 @@
+-- Card: Governance Role Matrix
+-- Viz: table
+-- Purpose: role coverage and readable/editable footprint.
+
+SELECT
+  agent_id,
+  role,
+  readable_entries,
+  restricted_readable_entries,
+  editable_entries,
+  granted_at
+FROM vw_governance_role_matrix
+ORDER BY agent_id ASC, role ASC;

--- a/sql/tob-dashboard/metabase/v1/10_recent_curated_knowledge.sql
+++ b/sql/tob-dashboard/metabase/v1/10_recent_curated_knowledge.sql
@@ -1,0 +1,16 @@
+-- Card: Recent Curated Knowledge
+-- Viz: table
+-- Purpose: show latest curated entries with visibility + tags.
+
+SELECT
+  updated_at,
+  owner_agent_id,
+  visibility,
+  coalesce(title, '(untitled)') AS title,
+  array_to_string(tags, ', ') AS tags_csv,
+  array_to_string(visible_to, ', ') AS visible_to_roles,
+  array_to_string(editable_by, ', ') AS editable_by_roles,
+  left(regexp_replace(content, '\s+', ' ', 'g'), 260) AS content_snippet
+FROM shared_knowledge
+ORDER BY updated_at DESC
+LIMIT 120;

--- a/sql/tob-dashboard/v1_seed_mock_data.sql
+++ b/sql/tob-dashboard/v1_seed_mock_data.sql
@@ -1,0 +1,283 @@
+-- LCM-PG toB dashboard v1 mock data seeding
+-- Deterministic enough for repeatable local demos on MacBook.
+
+BEGIN;
+
+-- Keep schema ready even before plugin runtime writes first rows.
+CREATE TABLE IF NOT EXISTS lcm_mirror (
+  mirror_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_key TEXT NOT NULL,
+  conversation_id BIGINT NOT NULL,
+  agent_id TEXT NOT NULL,
+  mode TEXT NOT NULL DEFAULT 'latest_nodes',
+  content TEXT NOT NULL,
+  summary_ids JSONB NOT NULL DEFAULT '[]',
+  content_hash TEXT NOT NULL,
+  session_id TEXT,
+  captured_at TIMESTAMPTZ NOT NULL,
+  ingested_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (conversation_id, content_hash)
+);
+
+CREATE INDEX IF NOT EXISTS lcm_mirror_session_key_idx
+  ON lcm_mirror (session_key, ingested_at DESC);
+CREATE INDEX IF NOT EXISTS lcm_mirror_agent_idx
+  ON lcm_mirror (agent_id, ingested_at DESC);
+
+CREATE TABLE IF NOT EXISTS knowledge_roles (
+  agent_id    TEXT NOT NULL,
+  role        TEXT NOT NULL,
+  granted_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (agent_id, role)
+);
+
+CREATE INDEX IF NOT EXISTS kr_role_idx ON knowledge_roles (role);
+
+CREATE TABLE IF NOT EXISTS shared_knowledge (
+  knowledge_id      UUID PRIMARY KEY,
+  owner_agent_id    TEXT NOT NULL,
+  visibility        TEXT NOT NULL DEFAULT 'shared'
+    CHECK (visibility IN ('shared', 'restricted', 'private')),
+  visible_to        TEXT[] NOT NULL DEFAULT '{}',
+  editable_by       TEXT[] NOT NULL DEFAULT '{}',
+  title             TEXT,
+  content           TEXT NOT NULL,
+  source_mirror_ids UUID[] NOT NULL DEFAULT '{}',
+  tags              TEXT[] NOT NULL DEFAULT '{}',
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS sk_visibility_idx ON shared_knowledge (visibility, updated_at DESC);
+CREATE INDEX IF NOT EXISTS sk_owner_idx ON shared_knowledge (owner_agent_id, updated_at DESC);
+CREATE INDEX IF NOT EXISTS sk_tags_idx ON shared_knowledge USING GIN (tags);
+CREATE INDEX IF NOT EXISTS sk_visible_to_idx ON shared_knowledge USING GIN (visible_to);
+CREATE INDEX IF NOT EXISTS sk_editable_by_idx ON shared_knowledge USING GIN (editable_by);
+
+-- Seed baseline roles used by v1 dashboard narrative.
+INSERT INTO knowledge_roles (agent_id, role) VALUES
+  ('main', 'admin'),
+  ('infra', 'researcher'),
+  ('finance', 'cost-analyst'),
+  ('security', 'compliance-reviewer')
+ON CONFLICT (agent_id, role) DO NOTHING;
+
+-- If shared-knowledge RLS policies are present, these settings align with admin bypass.
+SELECT set_config('app.agent_id', 'main', true);
+SELECT set_config('app.admin_role', 'admin', true);
+
+-- Mirror rows: ~35% sampling over 72 hours x 12 conversations => roughly 240-360 rows.
+WITH agents AS (
+  SELECT *
+  FROM (VALUES
+    (1, 'infra'),
+    (2, 'finance'),
+    (3, 'security'),
+    (4, 'main')
+  ) AS t(agent_ord, agent_id)
+),
+conversations AS (
+  SELECT
+    a.agent_id,
+    gs AS conv_idx,
+    (10000 + (a.agent_ord * 100) + gs)::bigint AS conversation_id,
+    format('agent:%s:demo-%s', a.agent_id, gs) AS session_key,
+    format('session-%s-%s', a.agent_id, gs) AS session_id
+  FROM agents a
+  CROSS JOIN generate_series(1, 3) AS gs
+),
+hours AS (
+  SELECT
+    generate_series(
+      date_trunc('hour', now()) - interval '71 hour',
+      date_trunc('hour', now()),
+      interval '1 hour'
+    ) AS captured_at
+),
+topic_map AS (
+  SELECT *
+  FROM (VALUES
+    ('infra', 'latency benchmark migration architecture'),
+    ('finance', 'cost tco decision budget waf'),
+    ('security', 'compliance governance security risk controls'),
+    ('main', 'cross-team synthesis decision memo')
+  ) AS t(agent_id, topic_terms)
+),
+candidate_rows AS (
+  SELECT
+    c.session_key,
+    c.conversation_id,
+    c.agent_id,
+    CASE
+      WHEN (extract(hour FROM h.captured_at)::int % 2) = 0 THEN 'latest_nodes'
+      ELSE 'root_view'
+    END AS mode,
+    format(
+      'Agent=%s conversation=%s captured_at=%s topics=%s phase=%s %s',
+      c.agent_id,
+      c.conversation_id,
+      to_char(h.captured_at, 'YYYY-MM-DD HH24:MI'),
+      tm.topic_terms,
+      (extract(hour FROM h.captured_at)::int % 6),
+      repeat(
+        CASE
+          WHEN c.agent_id = 'infra' THEN 'cold-start latency measurement '
+          WHEN c.agent_id = 'finance' THEN 'cost model scenario analysis '
+          WHEN c.agent_id = 'security' THEN 'compliance control validation '
+          ELSE 'cross-team summary alignment '
+        END,
+        4 + ((extract(hour FROM h.captured_at)::int + c.conv_idx) % 7)
+      )
+    ) AS content,
+    jsonb_build_array(
+      format('sum_%s_%s_%s_a', c.agent_id, c.conv_idx, to_char(h.captured_at, 'YYYYMMDDHH24')),
+      format('sum_%s_%s_%s_b', c.agent_id, c.conv_idx, to_char(h.captured_at, 'YYYYMMDDHH24'))
+    ) AS summary_ids,
+    md5(format('%s|%s|v1', c.conversation_id, to_char(h.captured_at, 'YYYYMMDDHH24MI'))) AS content_hash,
+    c.session_id,
+    h.captured_at
+  FROM conversations c
+  JOIN hours h ON TRUE
+  JOIN topic_map tm ON tm.agent_id = c.agent_id
+  WHERE mod(
+    abs((('x' || substr(md5(format(
+      '%s|%s|%s',
+      c.agent_id,
+      c.conversation_id,
+      to_char(h.captured_at, 'YYYYMMDDHH24')
+    )), 1, 8))::bit(32)::int)),
+    100
+  ) < 35
+)
+INSERT INTO lcm_mirror (
+  session_key,
+  conversation_id,
+  agent_id,
+  mode,
+  content,
+  summary_ids,
+  content_hash,
+  session_id,
+  captured_at
+)
+SELECT
+  session_key,
+  conversation_id,
+  agent_id,
+  mode,
+  content,
+  summary_ids,
+  content_hash,
+  session_id,
+  captured_at
+FROM candidate_rows
+ON CONFLICT (conversation_id, content_hash) DO NOTHING;
+
+WITH tag_pool AS (
+  SELECT ARRAY[
+    'latency',
+    'cost',
+    'compliance',
+    'risk',
+    'timeline',
+    'migration',
+    'ops',
+    'security',
+    'architecture',
+    'decision',
+    'waf',
+    'cold-start'
+  ]::text[] AS tags
+),
+base AS (
+  SELECT
+    gs AS idx,
+    (
+      substr(md5(format('sk:%s', gs)), 1, 8) || '-' ||
+      substr(md5(format('sk:%s', gs)), 9, 4) || '-' ||
+      '4' || substr(md5(format('sk:%s', gs)), 14, 3) || '-' ||
+      'a' || substr(md5(format('sk:%s', gs)), 18, 3) || '-' ||
+      substr(md5(format('sk:%s', gs)), 21, 12)
+    )::uuid AS knowledge_id,
+    CASE
+      WHEN gs % 10 = 0 THEN 'private'
+      WHEN gs % 10 BETWEEN 1 AND 3 THEN 'restricted'
+      ELSE 'shared'
+    END AS visibility,
+    CASE
+      WHEN gs % 4 = 0 THEN 'infra'
+      WHEN gs % 4 = 1 THEN 'finance'
+      WHEN gs % 4 = 2 THEN 'security'
+      ELSE 'main'
+    END AS owner_agent_id,
+    (SELECT tags[((gs % array_length(tags, 1)) + 1)] FROM tag_pool) AS tag_a,
+    (SELECT tags[(((gs * 3) % array_length(tags, 1)) + 1)] FROM tag_pool) AS tag_b
+  FROM generate_series(1, 60) AS gs
+),
+rows AS (
+  SELECT
+    knowledge_id,
+    owner_agent_id,
+    visibility,
+    CASE
+      WHEN visibility = 'restricted' AND idx % 3 = 0 THEN ARRAY['compliance-reviewer']::text[]
+      WHEN visibility = 'restricted' AND idx % 3 = 1 THEN ARRAY['cost-analyst']::text[]
+      WHEN visibility = 'restricted' THEN ARRAY['researcher']::text[]
+      ELSE ARRAY[]::text[]
+    END AS visible_to,
+    CASE
+      WHEN visibility = 'private' THEN ARRAY[]::text[]
+      ELSE ARRAY['admin']::text[]
+    END AS editable_by,
+    format('Demo Knowledge %s - %s', idx, initcap(replace(tag_a, '-', ' '))) AS title,
+    format(
+      'Seeded demo knowledge #%s. Primary topic=%s. Secondary topic=%s. This supports dashboard topic and governance visualizations.',
+      idx,
+      tag_a,
+      tag_b
+    ) AS content,
+    ARRAY[]::uuid[] AS source_mirror_ids,
+    CASE
+      WHEN tag_a = tag_b THEN ARRAY[tag_a]::text[]
+      ELSE ARRAY[tag_a, tag_b]::text[]
+    END AS tags,
+    now() - make_interval(hours => (60 - idx)) AS created_at,
+    now() - make_interval(hours => ((60 - idx) / 2)) AS updated_at
+  FROM base
+)
+INSERT INTO shared_knowledge (
+  knowledge_id,
+  owner_agent_id,
+  visibility,
+  visible_to,
+  editable_by,
+  title,
+  content,
+  source_mirror_ids,
+  tags,
+  created_at,
+  updated_at
+)
+SELECT
+  knowledge_id,
+  owner_agent_id,
+  visibility,
+  visible_to,
+  editable_by,
+  title,
+  content,
+  source_mirror_ids,
+  tags,
+  created_at,
+  updated_at
+FROM rows
+ON CONFLICT (knowledge_id) DO NOTHING;
+
+COMMIT;
+
+-- Summary counters for quick operator verification.
+SELECT 'lcm_mirror_rows' AS metric, count(*)::bigint AS value FROM lcm_mirror
+UNION ALL
+SELECT 'shared_knowledge_rows' AS metric, count(*)::bigint AS value FROM shared_knowledge
+UNION ALL
+SELECT 'knowledge_roles_rows' AS metric, count(*)::bigint AS value FROM knowledge_roles;

--- a/sql/tob-dashboard/v1_views.sql
+++ b/sql/tob-dashboard/v1_views.sql
@@ -1,0 +1,191 @@
+-- LCM-PG toB dashboard v1 views
+-- Decisions aligned with docs/tob-dashboard-demo-flow-plan.md §8:
+-- - SQL-view-only stack
+-- - Single-workspace demo
+-- - Topic analytics from tags only
+
+CREATE OR REPLACE VIEW vw_context_shift_hourly AS
+WITH ordered AS (
+  SELECT
+    mirror_id,
+    agent_id,
+    conversation_id,
+    captured_at,
+    date_trunc('hour', captured_at) AS bucket_hour,
+    char_length(content) AS content_chars,
+    COALESCE(jsonb_array_length(summary_ids), 0) AS summary_nodes,
+    lag(char_length(content)) OVER (
+      PARTITION BY conversation_id
+      ORDER BY captured_at, mirror_id
+    ) AS prev_content_chars,
+    lag(COALESCE(jsonb_array_length(summary_ids), 0)) OVER (
+      PARTITION BY conversation_id
+      ORDER BY captured_at, mirror_id
+    ) AS prev_summary_nodes
+  FROM lcm_mirror
+),
+scored AS (
+  SELECT
+    bucket_hour,
+    agent_id,
+    conversation_id,
+    content_chars,
+    summary_nodes,
+    CASE
+      WHEN prev_content_chars IS NULL OR prev_content_chars = 0 THEN 0::numeric
+      ELSE abs(content_chars - prev_content_chars)::numeric / prev_content_chars
+    END AS content_delta_ratio,
+    CASE
+      WHEN prev_summary_nodes IS NULL THEN 0::numeric
+      WHEN prev_summary_nodes = 0 AND summary_nodes = 0 THEN 0::numeric
+      WHEN prev_summary_nodes = 0 AND summary_nodes > 0 THEN 1::numeric
+      ELSE abs(summary_nodes - prev_summary_nodes)::numeric / prev_summary_nodes
+    END AS node_delta_ratio
+  FROM ordered
+)
+SELECT
+  bucket_hour,
+  agent_id,
+  count(*) AS snapshots,
+  count(DISTINCT conversation_id) AS active_conversations,
+  round(avg(content_chars)::numeric, 2) AS avg_content_chars,
+  round(avg(summary_nodes)::numeric, 2) AS avg_summary_nodes,
+  round(avg((content_delta_ratio * 0.7) + (node_delta_ratio * 0.3)), 4) AS shift_score_avg,
+  round(max((content_delta_ratio * 0.7) + (node_delta_ratio * 0.3)), 4) AS shift_score_peak
+FROM scored
+GROUP BY bucket_hour, agent_id
+ORDER BY bucket_hour DESC, agent_id;
+
+CREATE OR REPLACE VIEW vw_context_volume_daily AS
+SELECT
+  date_trunc('day', captured_at)::date AS day,
+  agent_id,
+  count(*) AS snapshots,
+  count(DISTINCT conversation_id) AS active_conversations,
+  round(avg(char_length(content))::numeric, 2) AS avg_content_chars,
+  round(percentile_cont(0.95) WITHIN GROUP (ORDER BY char_length(content))::numeric, 2) AS p95_content_chars,
+  round(avg(COALESCE(jsonb_array_length(summary_ids), 0))::numeric, 2) AS avg_summary_nodes
+FROM lcm_mirror
+GROUP BY day, agent_id
+ORDER BY day DESC, agent_id;
+
+CREATE OR REPLACE VIEW vw_topic_trends_daily AS
+WITH expanded AS (
+  SELECT
+    date_trunc('day', updated_at)::date AS day,
+    lower(trim(tag)) AS tag,
+    visibility,
+    owner_agent_id
+  FROM shared_knowledge
+  CROSS JOIN LATERAL unnest(tags) AS tag
+  WHERE trim(tag) <> ''
+)
+SELECT
+  day,
+  tag,
+  count(*) AS entries,
+  count(*) FILTER (WHERE visibility = 'shared') AS shared_entries,
+  count(*) FILTER (WHERE visibility = 'restricted') AS restricted_entries,
+  count(*) FILTER (WHERE visibility = 'private') AS private_entries,
+  count(DISTINCT owner_agent_id) AS distinct_owners
+FROM expanded
+GROUP BY day, tag
+ORDER BY day DESC, entries DESC, tag;
+
+CREATE OR REPLACE VIEW vw_topic_momentum_7d AS
+WITH anchor AS (
+  SELECT COALESCE(max(date_trunc('day', updated_at)::date), current_date) AS anchor_day
+  FROM shared_knowledge
+),
+daily AS (
+  SELECT
+    date_trunc('day', updated_at)::date AS day,
+    lower(trim(tag)) AS tag,
+    count(*) AS entries
+  FROM shared_knowledge
+  CROSS JOIN LATERAL unnest(tags) AS tag
+  WHERE trim(tag) <> ''
+  GROUP BY 1, 2
+),
+windowed AS (
+  SELECT
+    d.tag,
+    a.anchor_day,
+    sum(d.entries) FILTER (WHERE d.day BETWEEN a.anchor_day - 6 AND a.anchor_day) AS recent_7d,
+    sum(d.entries) FILTER (WHERE d.day BETWEEN a.anchor_day - 13 AND a.anchor_day - 7) AS previous_7d
+  FROM daily d
+  CROSS JOIN anchor a
+  GROUP BY d.tag, a.anchor_day
+)
+SELECT
+  anchor_day,
+  tag,
+  COALESCE(recent_7d, 0) AS recent_7d,
+  COALESCE(previous_7d, 0) AS previous_7d,
+  COALESCE(recent_7d, 0) - COALESCE(previous_7d, 0) AS delta_7d,
+  CASE
+    WHEN COALESCE(previous_7d, 0) = 0 THEN NULL
+    ELSE round(
+      (COALESCE(recent_7d, 0) - COALESCE(previous_7d, 0))::numeric
+      / previous_7d::numeric,
+      4
+    )
+  END AS growth_ratio
+FROM windowed
+WHERE COALESCE(recent_7d, 0) > 0 OR COALESCE(previous_7d, 0) > 0
+ORDER BY delta_7d DESC, recent_7d DESC, tag;
+
+CREATE OR REPLACE VIEW vw_governance_visibility_daily AS
+SELECT
+  date_trunc('day', updated_at)::date AS day,
+  count(*) AS total_entries,
+  count(*) FILTER (WHERE visibility = 'shared') AS shared_entries,
+  count(*) FILTER (WHERE visibility = 'restricted') AS restricted_entries,
+  count(*) FILTER (WHERE visibility = 'private') AS private_entries,
+  round(
+    (count(*) FILTER (WHERE visibility = 'restricted'))::numeric
+    / NULLIF(count(*), 0)::numeric,
+    4
+  ) AS restricted_ratio
+FROM shared_knowledge
+GROUP BY day
+ORDER BY day DESC;
+
+CREATE OR REPLACE VIEW vw_governance_role_matrix AS
+WITH role_base AS (
+  SELECT
+    agent_id,
+    role,
+    granted_at
+  FROM knowledge_roles
+),
+knowledge AS (
+  SELECT
+    knowledge_id,
+    owner_agent_id,
+    visibility,
+    visible_to,
+    editable_by
+  FROM shared_knowledge
+)
+SELECT
+  rb.agent_id,
+  rb.role,
+  rb.granted_at,
+  count(k.knowledge_id) FILTER (
+    WHERE k.visibility = 'shared'
+      OR (k.visibility = 'restricted' AND rb.role = ANY(k.visible_to))
+      OR k.owner_agent_id = rb.agent_id
+  ) AS readable_entries,
+  count(k.knowledge_id) FILTER (
+    WHERE rb.role = ANY(k.editable_by)
+      OR k.owner_agent_id = rb.agent_id
+  ) AS editable_entries,
+  count(k.knowledge_id) FILTER (
+    WHERE k.visibility = 'restricted'
+      AND rb.role = ANY(k.visible_to)
+  ) AS restricted_readable_entries
+FROM role_base rb
+LEFT JOIN knowledge k ON TRUE
+GROUP BY rb.agent_id, rb.role, rb.granted_at
+ORDER BY rb.agent_id, rb.role;


### PR DESCRIPTION
## Summary
- add v1 dashboard SQL views for context shift, volume, topic trends, momentum, and governance
- add deterministic synthetic mock seeding SQL for `lcm_mirror`, `shared_knowledge`, and `knowledge_roles`
- add one-command setup script: `scripts/tob-dashboard/setup-v1.sh`
- add implementation guide and README links
- add Metabase v1 query/card pack (`sql/tob-dashboard/metabase/v1/*.sql`) and assembly guide (`docs/tob-dashboard-v1-metabase-pack.md`)
- add Step 3 demo-day readiness:
  - QA gate script: `scripts/tob-dashboard/qa-v1.sh`
  - setup+QA wrapper: `scripts/tob-dashboard/demo-ready-v1.sh`
  - bilingual checklist: `docs/tob-dashboard-v1-demo-day-checklist.md`
- address issue #15 requests:
  - realistic local seed workflow (extract -> scrub -> generate -> optional apply)
  - local-only safety controls (`.gitignore` patterns + docs)
  - Chinese-first presenter pack (checklist + zh SQL alias examples)

## Issue #15 Coverage
### A — Realistic demo data
- [x] Documented local workflow: OpenClaw -> extract -> scrub -> generate SQL (offline/local)
- [x] Added local-only scripts under `scripts/tob-dashboard/local/`
- [x] Added `.gitignore` coverage for local realistic artifacts
- [x] Kept synthetic seed as default committed path (`setup-v1.sh`)

### B — Chinese-first Metabase
- [x] Added Chinese presenter checklist with card-title cheat sheet + talk track
- [x] Added Metabase language and alias guidance in pack doc
- [x] Added optional Chinese alias SQL examples under `sql/tob-dashboard/metabase/v1/zh/`

## Validation
- `bash -n scripts/tob-dashboard/setup-v1.sh`
- `bash -n scripts/tob-dashboard/qa-v1.sh`
- `bash -n scripts/tob-dashboard/demo-ready-v1.sh`
- `bash -n scripts/tob-dashboard/local/realistic-seed-v1.sh`
- `node --check scripts/tob-dashboard/local/extract-redacted-corpus.mjs`
- `node --check scripts/tob-dashboard/local/generate-realistic-seed-sql.mjs`

## Notes
- local PostgreSQL was not running in this environment, so end-to-end `psql` execution/full QA pass was not performed here
