### PR TITLE
feat(demo): issue #15 realistic local seed + chinese-first metabase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,14 @@ dist/
 .DS_Store
 .worktrees
 
+# Local-only toB demo artifacts (never commit realistic/derived data)
+.demo-local/
+data/tob-dashboard/local/
+sql/tob-dashboard/local-generated/
+*.demo.local.sql
+*.demo.local.csv
+*.demo.local.jsonl
+
 # TUI
 tui/lcm-tui
 dist/

--- a/README.md
+++ b/README.md
@@ -352,6 +352,8 @@ LCM core settings (`LCM_FRESH_TAIL_COUNT`, `LCM_CONTEXT_THRESHOLD`, session patt
 | [toB demo runbook](docs/tob-demo-macbook-runbook.md) | Fast MacBook demo flow with commands and checkpoints / MacBook 快速演示脚本 |
 | [toB dashboard v1 implementation](docs/tob-dashboard-v1-implementation.md) | SQL views + synthetic mock seeding + setup script / 看板 v1 实施落地 |
 | [toB dashboard v1 Metabase pack](docs/tob-dashboard-v1-metabase-pack.md) | Query-to-card mapping for fast dashboard assembly / Metabase 卡片映射 |
+| [toB dashboard v1 realistic local seed](docs/tob-dashboard-v1-realistic-local-seed.md) | Local-only extract/scrub/generate workflow for realistic demo data / 本地真实感数据流程 |
+| [toB dashboard v1 Chinese presenter checklist](docs/tob-dashboard-v1-chinese-presenter-checklist.md) | Chinese-first card title cheat sheet and talk track / 中文汇报清单 |
 | [toB dashboard v1 demo-day checklist](docs/tob-dashboard-v1-demo-day-checklist.md) | Pre-demo QA gate and fallback playbook / 演示前检查与兜底 |
 | [deep-dive-rdbms-proposal.md](liz-plans/deep-dive-rdbms-proposal.md) | Original RDBMS exploration notes / 早期 RDBMS 探索笔记 |
 

--- a/docs/tob-dashboard-v1-chinese-presenter-checklist.md
+++ b/docs/tob-dashboard-v1-chinese-presenter-checklist.md
@@ -1,0 +1,63 @@
+# 中文看板演示检查清单（toB v1）
+
+用于国内汇报场景的快速对照清单：卡片标题建议 + 三句话话术。
+
+---
+
+## 1) 看板与分栏命名建议
+
+- Dashboard：`LCM-PG 企业协同看板 v1`
+- Tab 1：`上下文迁移`
+- Tab 2：`知识主题`
+- Tab 3：`治理审计`
+
+---
+
+## 2) 卡片标题速查表（中英对照）
+
+| Card # | 英文默认名 | 中文建议标题 |
+|---|---|---|
+| 01 | KPI Overview | 全局指标总览 |
+| 02 | Context Shift Trend by Agent | 上下文迁移趋势（按 Agent） |
+| 03 | Context Volume Daily | 上下文体量（日） |
+| 04 | Latest Mirror Snapshots | 最新镜像快照明细 |
+| 05 | Top Topic Tags (30d) | 热门主题标签（30天） |
+| 06 | Topic Daily Trend (Top 8) | 主题趋势（Top 8） |
+| 07 | Topic Momentum (7d) | 主题动量（近7天 vs 前7天） |
+| 08 | Governance Visibility Mix | 治理可见性分布 |
+| 09 | Governance Role Matrix | 角色权限矩阵 |
+| 10 | Recent Curated Knowledge | 最新精选知识 |
+
+---
+
+## 3) 列名中文化建议（示例）
+
+优先使用 Metabase 显示名改写；若需在 SQL 里直接中文化，可参考：
+
+- `bucket_hour` -> `快照时间`
+- `agent_id` -> `Agent`
+- `shift_score_avg` -> `平均迁移分数`
+- `entries_30d` -> `30天条目数`
+- `restricted_ratio` -> `受限占比`
+
+可选 SQL 示例见：
+
+- `sql/tob-dashboard/metabase/v1/zh/`
+
+---
+
+## 4) 三句话话术（2分钟版开场）
+
+1. 「第一部分我们看上下文迁移：每个 Agent 的记忆变化是否稳定、可追踪。」
+2. 「第二部分看知识主题：信息有没有沉淀成可复用的结构化主题，而不是散落在对话里。」
+3. 「第三部分看治理审计：谁能看、谁能改、哪些是受限知识，现场可验证。」
+
+---
+
+## 5) 演示前 60 秒核对
+
+1. Metabase 语言是否已设为中文（若版本支持）
+2. 三个分栏是否为中文名
+3. Top 标签卡是否至少展示 8 个标签
+4. 治理页是否能看到 restricted 数据
+5. 最新精选知识表是否非空

--- a/docs/tob-dashboard-v1-implementation.md
+++ b/docs/tob-dashboard-v1-implementation.md
@@ -43,8 +43,14 @@ This guide implements the decisions in:
   `docs/tob-dashboard-v1-metabase-pack.md`
 - Metabase query files:
   `sql/tob-dashboard/metabase/v1/*.sql`
+- Chinese presenter checklist:
+  `docs/tob-dashboard-v1-chinese-presenter-checklist.md`
 - Demo-day checklist:
   `docs/tob-dashboard-v1-demo-day-checklist.md`
+- Realistic local seed workflow:
+  `docs/tob-dashboard-v1-realistic-local-seed.md`
+- Realistic local scripts:
+  `scripts/tob-dashboard/local/*`
 
 ---
 
@@ -119,9 +125,13 @@ Build dashboard cards from these views:
 - Seeder is idempotent on primary keys / unique constraints.
 - Re-running setup updates views and appends only non-conflicting mock rows.
 - If your environment has strict RLS enabled, run seeding with a DB user that can insert demo rows.
+- Synthetic seeding remains the default committed path.
+- Realistic data path is local-only and opt-in; do not commit local generated artifacts.
 
 ### 中文
 
 - Seed 脚本在主键/唯一键层面可重复执行。
 - 重复运行会刷新视图，只插入不冲突的数据。
 - 若环境启用了严格 RLS，请使用有插入权限的数据库账号执行演示注入。
+- 合成数据仍是仓库默认路径。
+- 真实感数据路径为本地可选流程，禁止提交本地生成产物。

--- a/docs/tob-dashboard-v1-metabase-pack.md
+++ b/docs/tob-dashboard-v1-metabase-pack.md
@@ -23,6 +23,36 @@ Then connect Metabase to the same PostgreSQL database (`lcm_demo` by default).
 
 ---
 
+## 1.1 Chinese-first Presenter Mode / 中文优先演示模式
+
+### EN
+
+For China stakeholder demos, prefer Chinese presentation labels:
+
+1. Set Metabase language to Chinese where available:
+   - Admin -> Settings -> Localization (or account-level language setting)
+2. Use Chinese dashboard/tab/card names.
+3. Prefer Chinese axis/legend labels via:
+   - Metabase display-name overrides, or
+   - SQL aliases (e.g. `AS "快照时间"`).
+
+Out of scope: full product UI translation across all Metabase versions.
+
+### 中文
+
+面向国内汇报时，建议采用中文优先展示：
+
+1. 若版本支持，将 Metabase 语言设置为中文：
+   - 管理后台 -> 设置 -> 本地化（或账号语言设置）
+2. 看板/分栏/卡片标题尽量中文化。
+3. 坐标轴与图例优先中文：
+   - 在 Metabase 中改显示名，或
+   - 在 SQL 中直接使用中文别名（如 `AS "快照时间"`）。
+
+说明：Metabase 产品 UI 是否完整汉化受版本影响，不属于本仓库控制范围。
+
+---
+
 ## 2) Dashboard Tabs / 看板分栏
 
 Create one dashboard with 3 tabs:
@@ -133,9 +163,31 @@ v1 以简洁为主，查询已内置时间窗口（如 30 天、72 小时）。
 3. Set visualization exactly per table in §3.
 4. Assemble into the 3-tab dashboard per §4.
 5. Save dashboard as: `LCM-PG toB Dashboard v1`.
+6. For Chinese-first demos, apply the checklist in `docs/tob-dashboard-v1-chinese-presenter-checklist.md`.
 
 1. 执行 `scripts/tob-dashboard/setup-v1.sh`。
 2. 在 Metabase 中用上述 SQL 文件创建 10 个原生查询问题。
 3. 按第 3 节设置图表类型与字段。
 4. 按第 4 节组装成 3 个分栏的 Dashboard。
 5. 保存名称：`LCM-PG toB Dashboard v1`。
+6. 若为中文汇报，请按 `docs/tob-dashboard-v1-chinese-presenter-checklist.md` 做最终标题与话术校对。
+
+---
+
+## 8) Chinese Alias Examples / 中文别名示例
+
+### EN
+
+Optional sample queries with Chinese column aliases are provided in:
+
+- `sql/tob-dashboard/metabase/v1/zh/`
+
+These are presenter-focused examples and do not replace the canonical EN queries.
+
+### 中文
+
+可选中文列别名示例位于：
+
+- `sql/tob-dashboard/metabase/v1/zh/`
+
+该目录用于演示呈现，不替代英文标准查询。

--- a/docs/tob-dashboard-v1-realistic-local-seed.md
+++ b/docs/tob-dashboard-v1-realistic-local-seed.md
@@ -1,0 +1,165 @@
+# toB Dashboard v1 Realistic Local Seed Workflow
+# toB 看板 v1 本地真实感种子数据流程
+
+This document addresses issue #15 requirements:
+
+- OpenClaw -> extract -> scrub -> generate realistic seed **locally**
+- keep synthetic default path as public baseline
+- never commit raw/PII workspace artifacts to remote
+
+本文用于满足 #15 要求：
+
+- OpenClaw -> 抽取 -> 脱敏 -> 本地生成真实感种子数据
+- 公共默认路径仍保持合成数据
+- 原始/含 PII 的工作区数据禁止提交远端
+
+---
+
+## 1) Safety Rules (Hard) / 安全铁律
+
+### EN
+
+1. Do not commit raw workspace dumps, copied session logs, credentials, or customer data.
+2. Do not commit generated realistic datasets derived from private data.
+3. Keep all realistic artifacts in local ignored paths (`.demo-local/...`).
+4. Commit only generators, templates, and sanitized examples.
+
+### 中文
+
+1. 禁止提交原始工作区导出、会话日志、凭据、客户数据。
+2. 禁止提交由私有数据衍生出的真实感数据集。
+3. 所有真实感产物仅放在本地忽略目录（`.demo-local/...`）。
+4. 仓库仅提交生成器、模板、脱敏示例。
+
+---
+
+## 2) Default vs Realistic Path / 默认路径 vs 真实感路径
+
+### EN
+
+- Default public path: `scripts/tob-dashboard/setup-v1.sh`
+  - uses synthetic seed SQL
+  - deterministic and safe for remote collaboration
+
+- Opt-in realistic local path:
+  - extract redacted corpus from local OpenClaw SQLite
+  - generate local SQL seed
+  - optionally apply to local PG
+
+### 中文
+
+- 公共默认路径：`scripts/tob-dashboard/setup-v1.sh`
+  - 使用合成种子
+  - 可复现且适合远程协作
+
+- 可选真实感本地路径：
+  - 从本地 OpenClaw SQLite 抽取脱敏语料
+  - 生成本地 SQL 种子
+  - 可选择写入本地 PG
+
+---
+
+## 3) Local Pipeline Scripts / 本地流水线脚本
+
+- `scripts/tob-dashboard/local/extract-redacted-corpus.mjs`
+  - source: local LCM SQLite (`~/.openclaw/lcm.db` by default)
+  - redacts emails/URLs/IP/secret-like tokens/paths/long numbers
+  - outputs local JSONL corpus
+
+- `scripts/tob-dashboard/local/generate-realistic-seed-sql.mjs`
+  - input: redacted corpus JSONL
+  - output: local SQL seed (`*.demo.local.sql`)
+  - creates realistic mirror/shared_knowledge inserts
+
+- `scripts/tob-dashboard/local/realistic-seed-v1.sh`
+  - one-command wrapper for extract + generate + optional apply
+
+---
+
+## 4) Usage / 使用方式
+
+### EN
+
+Generate local realistic seed (without applying):
+
+```bash
+scripts/tob-dashboard/local/realistic-seed-v1.sh \
+  --sqlite "$HOME/.openclaw/lcm.db" \
+  --out-dir ".demo-local/tob-dashboard" \
+  --limit 180 \
+  --mirror-rows 320 \
+  --shared-rows 60
+```
+
+Generate and apply into local PG:
+
+```bash
+scripts/tob-dashboard/local/realistic-seed-v1.sh \
+  --db-url "postgresql://$(whoami)@localhost:5432/lcm_demo" \
+  --apply
+```
+
+### 中文
+
+仅生成本地真实感种子（不入库）：
+
+```bash
+scripts/tob-dashboard/local/realistic-seed-v1.sh \
+  --sqlite "$HOME/.openclaw/lcm.db" \
+  --out-dir ".demo-local/tob-dashboard" \
+  --limit 180 \
+  --mirror-rows 320 \
+  --shared-rows 60
+```
+
+生成并写入本地 PG：
+
+```bash
+scripts/tob-dashboard/local/realistic-seed-v1.sh \
+  --db-url "postgresql://$(whoami)@localhost:5432/lcm_demo" \
+  --apply
+```
+
+---
+
+## 5) Optional LLM Paraphrase Path / 可选 LLM 改写路径
+
+### EN
+
+Optional and local-only:
+
+1. Use redacted corpus output as input text.
+2. Ask local/private model to paraphrase for demo narrative tone.
+3. Re-run SQL generation from paraphrased corpus.
+4. Keep outputs local and ignored by git.
+
+### 中文
+
+可选、且仅限本地：
+
+1. 用脱敏语料作为输入。
+2. 让本地/私有模型进行演示风格改写。
+3. 用改写后的语料再次生成 SQL。
+4. 产物继续留在本地忽略目录。
+
+---
+
+## 6) Git Ignore Coverage / 忽略规则覆盖
+
+These patterns are already ignored:
+
+- `.demo-local/`
+- `data/tob-dashboard/local/`
+- `sql/tob-dashboard/local-generated/`
+- `*.demo.local.sql`
+- `*.demo.local.csv`
+- `*.demo.local.jsonl`
+
+以下路径已加入忽略规则：
+
+- `.demo-local/`
+- `data/tob-dashboard/local/`
+- `sql/tob-dashboard/local-generated/`
+- `*.demo.local.sql`
+- `*.demo.local.csv`
+- `*.demo.local.jsonl`

--- a/scripts/tob-dashboard/local/extract-redacted-corpus.mjs
+++ b/scripts/tob-dashboard/local/extract-redacted-corpus.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { homedir } from "node:os";
+import { DatabaseSync } from "node:sqlite";
+
+function expandHome(input) {
+  if (!input) return input;
+  if (input === "~") return homedir();
+  if (input.startsWith("~/")) return resolve(homedir(), input.slice(2));
+  return resolve(input);
+}
+
+function parseArgs(argv) {
+  const out = {
+    sqlite: "~/.openclaw/lcm.db",
+    out: ".demo-local/tob-dashboard/redacted-corpus.jsonl",
+    limit: 180,
+    minChars: 120,
+    maxChars: 1200,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    const next = argv[i + 1];
+    if (token === "--sqlite" && next) {
+      out.sqlite = next;
+      i += 1;
+      continue;
+    }
+    if (token === "--out" && next) {
+      out.out = next;
+      i += 1;
+      continue;
+    }
+    if (token === "--limit" && next) {
+      out.limit = Math.max(1, Number.parseInt(next, 10) || out.limit);
+      i += 1;
+      continue;
+    }
+    if (token === "--min-chars" && next) {
+      out.minChars = Math.max(1, Number.parseInt(next, 10) || out.minChars);
+      i += 1;
+      continue;
+    }
+    if (token === "--max-chars" && next) {
+      out.maxChars = Math.max(80, Number.parseInt(next, 10) || out.maxChars);
+      i += 1;
+      continue;
+    }
+    if (token === "--help" || token === "-h") {
+      console.log(`Usage:
+  node scripts/tob-dashboard/local/extract-redacted-corpus.mjs [options]
+
+Options:
+  --sqlite <path>      Source LCM SQLite DB (default: ~/.openclaw/lcm.db)
+  --out <path>         Output JSONL (default: .demo-local/tob-dashboard/redacted-corpus.jsonl)
+  --limit <n>          Max summary rows to extract (default: 180)
+  --min-chars <n>      Minimum source content length (default: 120)
+  --max-chars <n>      Max chars per redacted snippet (default: 1200)
+`);
+      process.exit(0);
+    }
+  }
+  return out;
+}
+
+function parseAgentId(sessionKey, sessionId) {
+  if (typeof sessionKey === "string" && sessionKey.startsWith("agent:")) {
+    const parts = sessionKey.split(":");
+    if (parts.length >= 2 && parts[1]?.trim()) {
+      return parts[1].trim();
+    }
+  }
+  if (typeof sessionId === "string" && sessionId.trim()) {
+    return "main";
+  }
+  return "unknown";
+}
+
+function normalizeText(input) {
+  return String(input ?? "").replace(/\s+/g, " ").trim();
+}
+
+function redactText(input) {
+  let text = normalizeText(input);
+  if (!text) return text;
+
+  const replacements = [
+    [/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[REDACTED_EMAIL]"],
+    [/\bhttps?:\/\/[^\s/$.?#].[^\s]*/gi, "[REDACTED_URL]"],
+    [/\b(?:\d{1,3}\.){3}\d{1,3}\b/g, "[REDACTED_IP]"],
+    [/\bAKIA[0-9A-Z]{16}\b/g, "[REDACTED_AWS_KEY]"],
+    [/\b(?:ghp|github_pat|xox[baprs]|sk|rk)-[A-Za-z0-9_\-]{16,}\b/g, "[REDACTED_SECRET]"],
+    [/\b[a-f0-9]{32,}\b/gi, "[REDACTED_HASH]"],
+    [/(?:\/Users\/[^\s"'`]+|\/home\/[^\s"'`]+|[A-Za-z]:\\[^\s"'`]+)/g, "[REDACTED_PATH]"],
+    [/\b\d{7,}\b/g, "[REDACTED_NUMBER]"],
+    [/\+?\d[\d\-\s().]{7,}\d/g, "[REDACTED_PHONE]"],
+  ];
+
+  for (const [pattern, token] of replacements) {
+    text = text.replace(pattern, token);
+  }
+
+  return normalizeText(text);
+}
+
+function truncateText(input, maxChars) {
+  if (input.length <= maxChars) return input;
+  return `${input.slice(0, Math.max(0, maxChars - 3))}...`;
+}
+
+function ensureTables(db) {
+  const rows = db
+    .prepare(
+      `SELECT name
+       FROM sqlite_master
+       WHERE type='table'
+         AND name IN ('summaries', 'conversations')`,
+    )
+    .all();
+  const names = new Set(rows.map((row) => String(row.name)));
+  if (!names.has("summaries") || !names.has("conversations")) {
+    throw new Error("Source SQLite DB does not look like an LCM database (missing summaries/conversations).");
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const sqlitePath = expandHome(args.sqlite);
+  const outPath = expandHome(args.out);
+
+  if (!existsSync(sqlitePath)) {
+    throw new Error(`SQLite DB not found: ${sqlitePath}`);
+  }
+
+  const db = new DatabaseSync(sqlitePath);
+  ensureTables(db);
+
+  const rows = db
+    .prepare(
+      `SELECT
+         s.summary_id,
+         s.conversation_id,
+         s.kind,
+         s.depth,
+         s.content,
+         s.created_at,
+         c.session_key,
+         c.session_id
+       FROM summaries s
+       JOIN conversations c
+         ON c.conversation_id = s.conversation_id
+       WHERE length(trim(s.content)) >= ?
+       ORDER BY s.created_at DESC
+       LIMIT ?`,
+    )
+    .all(args.minChars, args.limit);
+
+  const outRows = [];
+  for (const row of rows) {
+    const redacted = truncateText(redactText(row.content), args.maxChars);
+    if (!redacted) continue;
+    const agentId = parseAgentId(row.session_key, row.session_id);
+    outRows.push({
+      record_id: `${agentId}:${row.summary_id}`,
+      agent_id: agentId,
+      summary_id: String(row.summary_id),
+      conversation_id: Number(row.conversation_id),
+      kind: String(row.kind ?? ""),
+      depth: Number(row.depth ?? 0),
+      created_at: String(row.created_at ?? ""),
+      source: "openclaw-lcm-sqlite",
+      text: redacted,
+    });
+  }
+
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, outRows.map((r) => JSON.stringify(r)).join("\n") + (outRows.length ? "\n" : ""));
+
+  const byAgent = new Map();
+  for (const row of outRows) {
+    byAgent.set(row.agent_id, (byAgent.get(row.agent_id) ?? 0) + 1);
+  }
+
+  console.log(`[lcm-pg] redacted corpus written: ${outPath}`);
+  console.log(`[lcm-pg] rows=${outRows.length} (requested limit=${args.limit})`);
+  for (const [agent, count] of [...byAgent.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+    console.log(`[lcm-pg] agent=${agent} rows=${count}`);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`[lcm-pg] extract-redacted-corpus failed: ${message}`);
+  process.exit(1);
+}

--- a/scripts/tob-dashboard/local/generate-realistic-seed-sql.mjs
+++ b/scripts/tob-dashboard/local/generate-realistic-seed-sql.mjs
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { homedir } from "node:os";
+
+function expandHome(input) {
+  if (!input) return input;
+  if (input === "~") return homedir();
+  if (input.startsWith("~/")) return resolve(homedir(), input.slice(2));
+  return resolve(input);
+}
+
+function parseArgs(argv) {
+  const out = {
+    corpus: ".demo-local/tob-dashboard/redacted-corpus.jsonl",
+    outSql: ".demo-local/tob-dashboard/generated/realistic_seed_v1.demo.local.sql",
+    mirrorRows: 320,
+    sharedRows: 60,
+    hours: 72,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    const next = argv[i + 1];
+    if (token === "--corpus" && next) {
+      out.corpus = next;
+      i += 1;
+      continue;
+    }
+    if (token === "--out-sql" && next) {
+      out.outSql = next;
+      i += 1;
+      continue;
+    }
+    if (token === "--mirror-rows" && next) {
+      out.mirrorRows = Math.max(1, Number.parseInt(next, 10) || out.mirrorRows);
+      i += 1;
+      continue;
+    }
+    if (token === "--shared-rows" && next) {
+      out.sharedRows = Math.max(1, Number.parseInt(next, 10) || out.sharedRows);
+      i += 1;
+      continue;
+    }
+    if (token === "--hours" && next) {
+      out.hours = Math.max(1, Number.parseInt(next, 10) || out.hours);
+      i += 1;
+      continue;
+    }
+    if (token === "--help" || token === "-h") {
+      console.log(`Usage:
+  node scripts/tob-dashboard/local/generate-realistic-seed-sql.mjs [options]
+
+Options:
+  --corpus <path>       Input redacted JSONL (default: .demo-local/tob-dashboard/redacted-corpus.jsonl)
+  --out-sql <path>      Output SQL file (default: .demo-local/tob-dashboard/generated/realistic_seed_v1.demo.local.sql)
+  --mirror-rows <n>     Target mirror rows (default: 320)
+  --shared-rows <n>     Target shared knowledge rows (default: 60)
+  --hours <n>           Time window in hours for generated timestamps (default: 72)
+`);
+      process.exit(0);
+    }
+  }
+  return out;
+}
+
+function stableHash(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function uuidFromSeed(seed) {
+  const h = stableHash(seed);
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-4${h.slice(13, 16)}-a${h.slice(17, 20)}-${h.slice(20, 32)}`;
+}
+
+function sqlLiteral(value) {
+  if (value == null) return "NULL";
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+function jsonLiteral(value) {
+  return sqlLiteral(JSON.stringify(value));
+}
+
+function textArrayLiteral(items) {
+  if (!items || items.length === 0) return "ARRAY[]::text[]";
+  const body = items.map((item) => sqlLiteral(item)).join(", ");
+  return `ARRAY[${body}]::text[]`;
+}
+
+function uuidArrayLiteral(items) {
+  if (!items || items.length === 0) return "ARRAY[]::uuid[]";
+  const body = items.map((item) => `${sqlLiteral(item)}::uuid`).join(", ");
+  return `ARRAY[${body}]::uuid[]`;
+}
+
+function normalize(text) {
+  return String(text ?? "").replace(/\s+/g, " ").trim();
+}
+
+function extractTags(text) {
+  const t = text.toLowerCase();
+  const out = new Set();
+  const rules = [
+    { tag: "latency", re: /\blatency\b|\bcold\s*start\b|\bp95\b|\bp50\b|\bresponse\b/ },
+    { tag: "cost", re: /\bcost\b|\btco\b|\bpricing\b|\bbudget\b|\bspend\b/ },
+    { tag: "compliance", re: /\bcompliance\b|\bsoc2\b|\bgdpr\b|\bhipaa\b|\bpolicy\b/ },
+    { tag: "risk", re: /\brisk\b|\btrade[- ]?off\b|\bissue\b|\bgap\b/ },
+    { tag: "timeline", re: /\btimeline\b|\bweek\b|\bmonth\b|\bdeadline\b/ },
+    { tag: "migration", re: /\bmigration\b|\bmigrate\b|\brollout\b/ },
+    { tag: "ops", re: /\bops\b|\boperation\b|\breliability\b|\bon[- ]?call\b/ },
+    { tag: "security", re: /\bsecurity\b|\bsecret\b|\bauth\b|\baccess\b/ },
+    { tag: "architecture", re: /\barchitecture\b|\bdesign\b|\bsystem\b|\bcomponent\b/ },
+    { tag: "decision", re: /\bdecision\b|\brecommend\b|\bconclusion\b/ },
+    { tag: "waf", re: /\bwaf\b|\bfirewall\b/ },
+    { tag: "cold-start", re: /\bcold[- ]?start\b/ },
+  ];
+
+  for (const rule of rules) {
+    if (rule.re.test(t)) out.add(rule.tag);
+  }
+  if (out.size === 0) out.add("ops");
+  return [...out].slice(0, 3);
+}
+
+function visibilityForIndex(i) {
+  if (i % 10 === 0) return "private";
+  if (i % 10 <= 3) return "restricted";
+  return "shared";
+}
+
+function roleForTags(tags) {
+  if (tags.includes("compliance") || tags.includes("security")) return "compliance-reviewer";
+  if (tags.includes("cost")) return "cost-analyst";
+  return "researcher";
+}
+
+function titleFromTags(tags, index) {
+  const first = tags[0] ?? "ops";
+  return `Realistic Demo Knowledge ${index}: ${first}`;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const corpusPath = expandHome(args.corpus);
+  const outSqlPath = expandHome(args.outSql);
+
+  if (!existsSync(corpusPath)) {
+    throw new Error(`Corpus not found: ${corpusPath}`);
+  }
+
+  const corpus = readFileSync(corpusPath, "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+    .filter((row) => typeof row.text === "string" && row.text.trim().length > 0);
+
+  if (corpus.length === 0) {
+    throw new Error("Corpus is empty after parsing/redaction.");
+  }
+
+  const now = Date.now();
+  const mirrorRows = [];
+  for (let i = 0; i < args.mirrorRows; i += 1) {
+    const base = corpus[i % corpus.length];
+    const tsOffsetMs = Math.floor((i / Math.max(1, args.mirrorRows - 1)) * args.hours * 3600 * 1000);
+    const capturedAt = new Date(now - ((args.hours * 3600 * 1000) - tsOffsetMs));
+    const agentId = String(base.agent_id || "main").trim() || "main";
+    const convSeed = `${agentId}:${base.conversation_id ?? 0}:${Math.floor(i / 6)}`;
+    const conversationId = Number.parseInt(stableHash(convSeed).slice(0, 12), 16) % 900000000;
+    const summaryA = `sum_${stableHash(`${base.summary_id}:${i}:a`).slice(0, 12)}`;
+    const summaryB = `sum_${stableHash(`${base.summary_id}:${i}:b`).slice(0, 12)}`;
+    const content = normalize(
+      `Agent ${agentId} synthesized update. ${base.text} Focus lane: ${extractTags(base.text).join(", ")}.`,
+    );
+
+    mirrorRows.push({
+      sessionKey: `agent:${agentId}:realistic-demo-${(i % 6) + 1}`,
+      conversationId,
+      agentId,
+      mode: i % 2 === 0 ? "latest_nodes" : "root_view",
+      content,
+      summaryIds: [summaryA, summaryB],
+      contentHash: stableHash(`mirror|${conversationId}|${capturedAt.toISOString()}|${content}`).slice(0, 64),
+      sessionId: `realistic-session-${agentId}-${(i % 6) + 1}`,
+      capturedAt: capturedAt.toISOString(),
+    });
+  }
+
+  const sharedRows = [];
+  for (let i = 0; i < args.sharedRows; i += 1) {
+    const base = corpus[(i * 3) % corpus.length];
+    const tags = extractTags(base.text);
+    const visibility = visibilityForIndex(i + 1);
+    const ownerAgentId = String(base.agent_id || "main").trim() || "main";
+    const visibleRole = roleForTags(tags);
+    const knowledgeId = uuidFromSeed(`knowledge|${ownerAgentId}|${i}|${base.summary_id}`);
+    const createdAt = new Date(now - (args.sharedRows - i) * 3600 * 1000);
+    const updatedAt = new Date(createdAt.getTime() + 30 * 60 * 1000);
+
+    sharedRows.push({
+      knowledgeId,
+      ownerAgentId,
+      visibility,
+      visibleTo: visibility === "restricted" ? [visibleRole] : [],
+      editableBy: visibility === "private" ? [] : ["admin"],
+      title: titleFromTags(tags, i + 1),
+      content: normalize(
+        `Curated from redacted workspace corpus. ${base.text} Recommended action: review with ${visibleRole}.`,
+      ),
+      sourceMirrorIds: [],
+      tags,
+      createdAt: createdAt.toISOString(),
+      updatedAt: updatedAt.toISOString(),
+    });
+  }
+
+  const sql = [];
+  sql.push("-- Generated by scripts/tob-dashboard/local/generate-realistic-seed-sql.mjs");
+  sql.push("-- Local-only artifact. Do NOT commit generated realistic data.");
+  sql.push("BEGIN;");
+  sql.push("");
+  sql.push("INSERT INTO knowledge_roles (agent_id, role) VALUES");
+  sql.push("  ('main', 'admin'),");
+  sql.push("  ('infra', 'researcher'),");
+  sql.push("  ('finance', 'cost-analyst'),");
+  sql.push("  ('security', 'compliance-reviewer')");
+  sql.push("ON CONFLICT (agent_id, role) DO NOTHING;");
+  sql.push("");
+  sql.push("SELECT set_config('app.agent_id', 'main', true);");
+  sql.push("SELECT set_config('app.admin_role', 'admin', true);");
+  sql.push("");
+
+  sql.push("INSERT INTO lcm_mirror (");
+  sql.push("  session_key, conversation_id, agent_id, mode, content, summary_ids, content_hash, session_id, captured_at");
+  sql.push(") VALUES");
+  sql.push(
+    mirrorRows
+      .map((row) => {
+        return `  (${[
+          sqlLiteral(row.sessionKey),
+          row.conversationId,
+          sqlLiteral(row.agentId),
+          sqlLiteral(row.mode),
+          sqlLiteral(row.content),
+          `${jsonLiteral(row.summaryIds)}::jsonb`,
+          sqlLiteral(row.contentHash),
+          sqlLiteral(row.sessionId),
+          `${sqlLiteral(row.capturedAt)}::timestamptz`,
+        ].join(", ")})`;
+      })
+      .join(",\n"),
+  );
+  sql.push("ON CONFLICT (conversation_id, content_hash) DO NOTHING;");
+  sql.push("");
+
+  sql.push("INSERT INTO shared_knowledge (");
+  sql.push("  knowledge_id, owner_agent_id, visibility, visible_to, editable_by, title, content, source_mirror_ids, tags, created_at, updated_at");
+  sql.push(") VALUES");
+  sql.push(
+    sharedRows
+      .map((row) => {
+        return `  (${[
+          `${sqlLiteral(row.knowledgeId)}::uuid`,
+          sqlLiteral(row.ownerAgentId),
+          sqlLiteral(row.visibility),
+          textArrayLiteral(row.visibleTo),
+          textArrayLiteral(row.editableBy),
+          sqlLiteral(row.title),
+          sqlLiteral(row.content),
+          uuidArrayLiteral(row.sourceMirrorIds),
+          textArrayLiteral(row.tags),
+          `${sqlLiteral(row.createdAt)}::timestamptz`,
+          `${sqlLiteral(row.updatedAt)}::timestamptz`,
+        ].join(", ")})`;
+      })
+      .join(",\n"),
+  );
+  sql.push("ON CONFLICT (knowledge_id) DO NOTHING;");
+  sql.push("");
+  sql.push("COMMIT;");
+  sql.push("");
+  sql.push("SELECT 'lcm_mirror_rows' AS metric, count(*)::bigint AS value FROM lcm_mirror");
+  sql.push("UNION ALL");
+  sql.push("SELECT 'shared_knowledge_rows' AS metric, count(*)::bigint AS value FROM shared_knowledge");
+  sql.push("UNION ALL");
+  sql.push("SELECT 'knowledge_roles_rows' AS metric, count(*)::bigint AS value FROM knowledge_roles;");
+
+  mkdirSync(dirname(outSqlPath), { recursive: true });
+  writeFileSync(outSqlPath, `${sql.join("\n")}\n`);
+
+  console.log(`[lcm-pg] realistic SQL seed generated: ${outSqlPath}`);
+  console.log(`[lcm-pg] mirror_rows=${mirrorRows.length} shared_rows=${sharedRows.length} corpus_rows=${corpus.length}`);
+}
+
+try {
+  main();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`[lcm-pg] generate-realistic-seed-sql failed: ${message}`);
+  process.exit(1);
+}

--- a/scripts/tob-dashboard/local/realistic-seed-v1.sh
+++ b/scripts/tob-dashboard/local/realistic-seed-v1.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+DEFAULT_SQLITE="$HOME/.openclaw/lcm.db"
+DEFAULT_DB_URL="postgresql://$(whoami)@localhost:5432/lcm_demo"
+DEFAULT_OUT_DIR="${ROOT_DIR}/.demo-local/tob-dashboard"
+
+SQLITE_PATH="${SQLITE_PATH:-$DEFAULT_SQLITE}"
+DB_URL="${DB_URL:-$DEFAULT_DB_URL}"
+OUT_DIR="${OUT_DIR:-$DEFAULT_OUT_DIR}"
+LIMIT="${LIMIT:-180}"
+MIRROR_ROWS="${MIRROR_ROWS:-320}"
+SHARED_ROWS="${SHARED_ROWS:-60}"
+APPLY="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sqlite)
+      SQLITE_PATH="${2:-$SQLITE_PATH}"
+      shift 2
+      ;;
+    --db-url)
+      DB_URL="${2:-$DB_URL}"
+      shift 2
+      ;;
+    --out-dir)
+      OUT_DIR="${2:-$OUT_DIR}"
+      shift 2
+      ;;
+    --limit)
+      LIMIT="${2:-$LIMIT}"
+      shift 2
+      ;;
+    --mirror-rows)
+      MIRROR_ROWS="${2:-$MIRROR_ROWS}"
+      shift 2
+      ;;
+    --shared-rows)
+      SHARED_ROWS="${2:-$SHARED_ROWS}"
+      shift 2
+      ;;
+    --apply)
+      APPLY="true"
+      shift 1
+      ;;
+    --help|-h)
+      cat <<'EOF'
+Usage:
+  scripts/tob-dashboard/local/realistic-seed-v1.sh [options]
+
+Options:
+  --sqlite <path>        Source OpenClaw LCM SQLite DB (default: ~/.openclaw/lcm.db)
+  --db-url <url>         Target PG URL for optional apply (default: postgresql://$(whoami)@localhost:5432/lcm_demo)
+  --out-dir <path>       Local output directory (default: .demo-local/tob-dashboard)
+  --limit <n>            Max redacted corpus rows extracted from SQLite (default: 180)
+  --mirror-rows <n>      Generated realistic mirror rows (default: 320)
+  --shared-rows <n>      Generated realistic shared knowledge rows (default: 60)
+  --apply                Apply generated SQL into target PG DB
+
+Security:
+  Generated realistic artifacts are local-only and ignored by git.
+EOF
+      exit 0
+      ;;
+    *)
+      echo "[lcm-pg] unknown arg: $1"
+      exit 1
+      ;;
+  esac
+done
+
+CORPUS_PATH="${OUT_DIR}/redacted-corpus.jsonl"
+SEED_SQL_PATH="${OUT_DIR}/generated/realistic_seed_v1.demo.local.sql"
+
+echo "[lcm-pg] realistic seed pipeline (local-only)"
+echo "[lcm-pg] sqlite=${SQLITE_PATH}"
+echo "[lcm-pg] out_dir=${OUT_DIR}"
+echo "[lcm-pg] db_url=${DB_URL}"
+
+node "${ROOT_DIR}/scripts/tob-dashboard/local/extract-redacted-corpus.mjs" \
+  --sqlite "${SQLITE_PATH}" \
+  --out "${CORPUS_PATH}" \
+  --limit "${LIMIT}"
+
+node "${ROOT_DIR}/scripts/tob-dashboard/local/generate-realistic-seed-sql.mjs" \
+  --corpus "${CORPUS_PATH}" \
+  --out-sql "${SEED_SQL_PATH}" \
+  --mirror-rows "${MIRROR_ROWS}" \
+  --shared-rows "${SHARED_ROWS}"
+
+echo "[lcm-pg] generated sql: ${SEED_SQL_PATH}"
+
+if [[ "${APPLY}" == "true" ]]; then
+  echo "[lcm-pg] applying realistic local SQL to ${DB_URL} ..."
+  psql "${DB_URL}" -v ON_ERROR_STOP=1 -f "${SEED_SQL_PATH}"
+  psql "${DB_URL}" -v ON_ERROR_STOP=1 -f "${ROOT_DIR}/sql/tob-dashboard/v1_views.sql"
+  echo "[lcm-pg] apply done."
+else
+  echo "[lcm-pg] apply skipped (use --apply to insert into PostgreSQL)."
+fi

--- a/sql/tob-dashboard/metabase/v1/zh/02_context_shift_trend_zh.sql
+++ b/sql/tob-dashboard/metabase/v1/zh/02_context_shift_trend_zh.sql
@@ -1,0 +1,13 @@
+-- 中文示例：上下文迁移趋势（按 Agent）
+-- 建议图表：折线图
+
+SELECT
+  bucket_hour AS "快照时间",
+  agent_id AS "Agent",
+  shift_score_avg AS "平均迁移分数",
+  shift_score_peak AS "峰值迁移分数",
+  snapshots AS "快照数",
+  active_conversations AS "活跃会话数"
+FROM vw_context_shift_hourly
+WHERE bucket_hour >= now() - interval '72 hours'
+ORDER BY bucket_hour ASC, agent_id ASC;

--- a/sql/tob-dashboard/metabase/v1/zh/10_recent_curated_knowledge_zh.sql
+++ b/sql/tob-dashboard/metabase/v1/zh/10_recent_curated_knowledge_zh.sql
@@ -1,0 +1,15 @@
+-- 中文示例：最新精选知识
+-- 建议图表：表格
+
+SELECT
+  updated_at AS "更新时间",
+  owner_agent_id AS "所有者Agent",
+  visibility AS "可见性",
+  coalesce(title, '(未命名)') AS "标题",
+  array_to_string(tags, ', ') AS "标签",
+  array_to_string(visible_to, ', ') AS "可见角色",
+  array_to_string(editable_by, ', ') AS "可编辑角色",
+  left(regexp_replace(content, '\s+', ' ', 'g'), 260) AS "内容摘要"
+FROM shared_knowledge
+ORDER BY updated_at DESC
+LIMIT 120;

--- a/sql/tob-dashboard/metabase/v1/zh/README.md
+++ b/sql/tob-dashboard/metabase/v1/zh/README.md
@@ -1,0 +1,16 @@
+# Chinese Alias Query Examples (v1)
+# 中文列别名查询示例（v1）
+
+These files are optional presenter-focused examples for Chinese-first demos.
+
+这些文件用于中文优先演示场景，可选使用。
+
+Notes:
+
+- Keep canonical dashboard logic in `../` (EN query pack).
+- Use these when you want SQL-level Chinese aliases directly in chart fields.
+
+说明：
+
+- 标准逻辑以 `../` 英文查询包为准。
+- 当你希望图表字段直接显示中文时，可使用本目录示例。


### PR DESCRIPTION
## Summary
- add local-only realistic seed workflow (extract -> scrub -> generate -> optional apply)
- keep synthetic seed as default committed path
- add explicit local artifact safety controls in `.gitignore`
- add Chinese-first Metabase presenter materials
- add optional Chinese SQL alias examples under `sql/tob-dashboard/metabase/v1/zh/`

## Issue Coverage
Addresses #15.

### A — Realistic demo data
- documented OpenClaw -> extract -> scrub -> generate workflow in `docs/tob-dashboard-v1-realistic-local-seed.md`
- added local scripts under `scripts/tob-dashboard/local/`
- added local-only ignore patterns to prevent committing realistic data artifacts
- preserved synthetic default path via `scripts/tob-dashboard/setup-v1.sh`

### B — Chinese-first Metabase
- added Chinese presenter checklist (`docs/tob-dashboard-v1-chinese-presenter-checklist.md`)
- updated Metabase pack with Chinese-language setup + alias guidance
- added optional zh query examples for Chinese column aliases

## Validation
- `bash -n scripts/tob-dashboard/local/realistic-seed-v1.sh`
- `node --check scripts/tob-dashboard/local/extract-redacted-corpus.mjs`
- `node --check scripts/tob-dashboard/local/generate-realistic-seed-sql.mjs`
- doc/reference consistency checks via `rg`

## Notes
- this change intentionally avoids committing any raw workspace data or generated realistic datasets
- end-to-end DB apply path requires local SQLite/PG availability at runtime
