### PR TITLE
feat(demo): Chinese-first Metabase presenter docs + zh SQL examples

### DIFF
--- a/docs/tob-dashboard-v1-chinese-presenter-checklist.md
+++ b/docs/tob-dashboard-v1-chinese-presenter-checklist.md
@@ -1,0 +1,63 @@
+# 中文看板演示检查清单（toB v1）
+
+用于国内汇报场景的快速对照清单：卡片标题建议 + 三句话话术。
+
+---
+
+## 1) 看板与分栏命名建议
+
+- Dashboard：`LCM-PG 企业协同看板 v1`
+- Tab 1：`上下文迁移`
+- Tab 2：`知识主题`
+- Tab 3：`治理审计`
+
+---
+
+## 2) 卡片标题速查表（中英对照）
+
+| Card # | 英文默认名 | 中文建议标题 |
+|---|---|---|
+| 01 | KPI Overview | 全局指标总览 |
+| 02 | Context Shift Trend by Agent | 上下文迁移趋势（按 Agent） |
+| 03 | Context Volume Daily | 上下文体量（日） |
+| 04 | Latest Mirror Snapshots | 最新镜像快照明细 |
+| 05 | Top Topic Tags (30d) | 热门主题标签（30天） |
+| 06 | Topic Daily Trend (Top 8) | 主题趋势（Top 8） |
+| 07 | Topic Momentum (7d) | 主题动量（近7天 vs 前7天） |
+| 08 | Governance Visibility Mix | 治理可见性分布 |
+| 09 | Governance Role Matrix | 角色权限矩阵 |
+| 10 | Recent Curated Knowledge | 最新精选知识 |
+
+---
+
+## 3) 列名中文化建议（示例）
+
+优先使用 Metabase 显示名改写；若需在 SQL 里直接中文化，可参考：
+
+- `bucket_hour` -> `快照时间`
+- `agent_id` -> `Agent`
+- `shift_score_avg` -> `平均迁移分数`
+- `entries_30d` -> `30天条目数`
+- `restricted_ratio` -> `受限占比`
+
+可选 SQL 示例见：
+
+- `sql/tob-dashboard/metabase/v1/zh/`
+
+---
+
+## 4) 三句话话术（2分钟版开场）
+
+1. 「第一部分我们看上下文迁移：每个 Agent 的记忆变化是否稳定、可追踪。」
+2. 「第二部分看知识主题：信息有没有沉淀成可复用的结构化主题，而不是散落在对话里。」
+3. 「第三部分看治理审计：谁能看、谁能改、哪些是受限知识，现场可验证。」
+
+---
+
+## 5) 演示前 60 秒核对
+
+1. Metabase 语言是否已设为中文（若版本支持）
+2. 三个分栏是否为中文名
+3. Top 标签卡是否至少展示 8 个标签
+4. 治理页是否能看到 restricted 数据
+5. 最新精选知识表是否非空

--- a/docs/tob-dashboard-v1-metabase-pack.md
+++ b/docs/tob-dashboard-v1-metabase-pack.md
@@ -23,6 +23,36 @@ Then connect Metabase to the same PostgreSQL database (`lcm_demo` by default).
 
 ---
 
+## 1.1 Chinese-first Presenter Mode / 中文优先演示模式
+
+### EN
+
+For China stakeholder demos, prefer Chinese presentation labels:
+
+1. Set Metabase language to Chinese where available:
+   - Admin -> Settings -> Localization (or account-level language setting)
+2. Use Chinese dashboard/tab/card names.
+3. Prefer Chinese axis/legend labels via:
+   - Metabase display-name overrides, or
+   - SQL aliases (e.g. `AS "快照时间"`).
+
+Out of scope: full product UI translation across all Metabase versions.
+
+### 中文
+
+面向国内汇报时，建议采用中文优先展示：
+
+1. 若版本支持，将 Metabase 语言设置为中文：
+   - 管理后台 -> 设置 -> 本地化（或账号语言设置）
+2. 看板/分栏/卡片标题尽量中文化。
+3. 坐标轴与图例优先中文：
+   - 在 Metabase 中改显示名，或
+   - 在 SQL 中直接使用中文别名（如 `AS "快照时间"`）。
+
+说明：Metabase 产品 UI 是否完整汉化受版本影响，不属于本仓库控制范围。
+
+---
+
 ## 2) Dashboard Tabs / 看板分栏
 
 Create one dashboard with 3 tabs:
@@ -133,9 +163,31 @@ v1 以简洁为主，查询已内置时间窗口（如 30 天、72 小时）。
 3. Set visualization exactly per table in §3.
 4. Assemble into the 3-tab dashboard per §4.
 5. Save dashboard as: `LCM-PG toB Dashboard v1`.
+6. For Chinese-first demos, apply the checklist in `docs/tob-dashboard-v1-chinese-presenter-checklist.md`.
 
 1. 执行 `scripts/tob-dashboard/setup-v1.sh`。
 2. 在 Metabase 中用上述 SQL 文件创建 10 个原生查询问题。
 3. 按第 3 节设置图表类型与字段。
 4. 按第 4 节组装成 3 个分栏的 Dashboard。
 5. 保存名称：`LCM-PG toB Dashboard v1`。
+6. 若为中文汇报，请按 `docs/tob-dashboard-v1-chinese-presenter-checklist.md` 做最终标题与话术校对。
+
+---
+
+## 8) Chinese Alias Examples / 中文别名示例
+
+### EN
+
+Optional sample queries with Chinese column aliases are provided in:
+
+- `sql/tob-dashboard/metabase/v1/zh/`
+
+These are presenter-focused examples and do not replace the canonical EN queries.
+
+### 中文
+
+可选中文列别名示例位于：
+
+- `sql/tob-dashboard/metabase/v1/zh/`
+
+该目录用于演示呈现，不替代英文标准查询。

--- a/sql/tob-dashboard/metabase/v1/zh/02_context_shift_trend_zh.sql
+++ b/sql/tob-dashboard/metabase/v1/zh/02_context_shift_trend_zh.sql
@@ -1,0 +1,13 @@
+-- 中文示例：上下文迁移趋势（按 Agent）
+-- 建议图表：折线图
+
+SELECT
+  bucket_hour AS "快照时间",
+  agent_id AS "Agent",
+  shift_score_avg AS "平均迁移分数",
+  shift_score_peak AS "峰值迁移分数",
+  snapshots AS "快照数",
+  active_conversations AS "活跃会话数"
+FROM vw_context_shift_hourly
+WHERE bucket_hour >= now() - interval '72 hours'
+ORDER BY bucket_hour ASC, agent_id ASC;

--- a/sql/tob-dashboard/metabase/v1/zh/10_recent_curated_knowledge_zh.sql
+++ b/sql/tob-dashboard/metabase/v1/zh/10_recent_curated_knowledge_zh.sql
@@ -1,0 +1,15 @@
+-- 中文示例：最新精选知识
+-- 建议图表：表格
+
+SELECT
+  updated_at AS "更新时间",
+  owner_agent_id AS "所有者Agent",
+  visibility AS "可见性",
+  coalesce(title, '(未命名)') AS "标题",
+  array_to_string(tags, ', ') AS "标签",
+  array_to_string(visible_to, ', ') AS "可见角色",
+  array_to_string(editable_by, ', ') AS "可编辑角色",
+  left(regexp_replace(content, '\s+', ' ', 'g'), 260) AS "内容摘要"
+FROM shared_knowledge
+ORDER BY updated_at DESC
+LIMIT 120;

--- a/sql/tob-dashboard/metabase/v1/zh/README.md
+++ b/sql/tob-dashboard/metabase/v1/zh/README.md
@@ -1,0 +1,16 @@
+# Chinese Alias Query Examples (v1)
+# 中文列别名查询示例（v1）
+
+These files are optional presenter-focused examples for Chinese-first demos.
+
+这些文件用于中文优先演示场景，可选使用。
+
+Notes:
+
+- Keep canonical dashboard logic in `../` (EN query pack).
+- Use these when you want SQL-level Chinese aliases directly in chart fields.
+
+说明：
+
+- 标准逻辑以 `../` 英文查询包为准。
+- 当你希望图表字段直接显示中文时，可使用本目录示例。


### PR DESCRIPTION
## Summary

Cherry-picked **Chinese UI portion only** from PR #17 (`feature-tob-dashboard-v1-impl`), excluding the realistic local seed pipeline scripts.

- Add **Chinese presenter checklist** (`docs/tob-dashboard-v1-chinese-presenter-checklist.md`) — card title cheat sheet + demo talking points for Chinese stakeholders
- Update **Metabase pack** (`docs/tob-dashboard-v1-metabase-pack.md`) — Chinese localization guidance (instance language, column aliases)
- Add optional **zh SQL alias examples** under `sql/tob-dashboard/metabase/v1/zh/` — context shift trend + curated knowledge with Chinese column names

## What is NOT included (intentionally)

The realistic local seed pipeline (`scripts/tob-dashboard/local/`, `docs/tob-dashboard-v1-realistic-local-seed.md`) is excluded. Demo data was generated separately via Codex and lives locally only — never committed to this repo.

## Related

- Partially addresses #15 (Chinese UI portion)
- PR #17 remains open for reference but will not be merged as-is

## 中文说明

从 PR #17 中只取了**中文演示相关**文件：演示清单、Metabase 中文化指引、可选的中文列别名 SQL 示例。本地 seed pipeline 脚本不在此 PR 范围内。

Made with [Cursor](https://cursor.com)